### PR TITLE
List of nodes 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'hashie'
 gem 'odyssey'
 gem 'rollbar'
 gem 'oj', '~> 2.12.14'
+gem 'enumerize', '~> 1.1.1'
 
 #TODO switch to thoughtbot's latest release once PRs are merged & released:
 # - https://github.com/thoughtbot/administrate/pull/580 # sidebar config
@@ -63,10 +64,11 @@ group :test, :development do
   gem 'pry'
 end
 
-group :test do 
+group :test do
   gem 'shoulda-matchers', '~> 3.1'
   gem 'rails-controller-testing', '~> 0.1.1'
   gem 'database_cleaner', '~> 1.5.3'
+  gem 'shoulda-kept-assign-to', '~> 1.1.0'
 end
 
 platforms :mingw, :mswin do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
+    enumerize (1.1.1)
+      activesupport (>= 3.2)
     erubis (2.7.0)
     execjs (2.6.0)
     fabrication (2.15.0)
@@ -304,6 +306,8 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     selectize-rails (0.12.1)
+    shoulda-kept-assign-to (1.1.0)
+      shoulda-matchers (>= 2.1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     simplecov (0.11.2)
@@ -373,6 +377,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   draper!
+  enumerize (~> 1.1.1)
   fabrication (~> 2.15.0)
   faker (~> 1.6.3)
   friendly_id!
@@ -399,6 +404,7 @@ DEPENDENCIES
   rollbar
   rspec-rails (>= 3.5.0.beta3)
   sass-rails (~> 5.0)
+  shoulda-kept-assign-to (~> 1.1.0)
   shoulda-matchers (~> 3.1)
   simple_form!
   simplecov (~> 0.11.2)

--- a/app/controllers/editorial/nodes_controller.rb
+++ b/app/controllers/editorial/nodes_controller.rb
@@ -1,0 +1,6 @@
+class Editorial::NodesController < ApplicationController
+  def index
+    @section = Section.find_by slug: params[:section]
+    @nodes = @section.nodes.order(updated_at: :desc).decorate
+  end
+end

--- a/app/decorators/node_decorator.rb
+++ b/app/decorators/node_decorator.rb
@@ -2,7 +2,11 @@ class NodeDecorator < Draper::Decorator
   delegate_all
 
   def edit_url
-    base_url = "/nodes/#{id}/edit"
+    "/editorial/nodes/#{id}/edit"
+  end
+
+  def updated_at
+    object.updated_at.strftime '%d %b %Y, %I:%M%P'
   end
 
 end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -1,5 +1,5 @@
 class Node < ApplicationRecord
-  extend FriendlyId
+  extend FriendlyId, Enumerize
   friendly_id :name, use: :slugged, routes: :default
 
   acts_as_tree order: 'order_num ASC'
@@ -8,6 +8,8 @@ class Node < ApplicationRecord
   has_one :content_block
 
   before_save :ensure_order_num_present
+
+  enumerize :state, in: %w(draft published)
 
   def ancestry
     arr = [self]

--- a/app/views/editorial/nodes/index.html.haml
+++ b/app/views/editorial/nodes/index.html.haml
@@ -1,0 +1,9 @@
+%h1
+  All pages in #{@section.name}
+
+-@nodes.each do |node|
+  %div
+    %a{href: nodes_path(section: @section.slug, path: node.path)}
+      %span= node.name
+      %span= node.state
+      %span= node.updated_at

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,13 @@ module GovAuBeta
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+      g.view_specs false
+      g.decorator false
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users
 
+  namespace :editorial do
+    get '/:section/nodes' => 'nodes#index'
+  end
+
   namespace :admin do
     resources :agencies
     resources :topics

--- a/db/migrate/20160606011512_add_state_to_nodes.rb
+++ b/db/migrate/20160606011512_add_state_to_nodes.rb
@@ -1,0 +1,5 @@
+class AddStateToNodes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :nodes, :state, :string, null: false, default: 'draft'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,9 +44,10 @@ ActiveRecord::Schema.define(version: 20160606021046) do
     t.string   "name"
     t.string   "slug"
     t.integer  "order_num"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string   "uuid",       null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.string   "uuid",                         null: false
+    t.string   "state",      default: "draft", null: false
     t.index ["parent_id"], name: "index_nodes_on_parent_id", using: :btree
     t.index ["section_id"], name: "index_nodes_on_section_id", using: :btree
   end

--- a/spec/controllers/editorial/nodes_controller_spec.rb
+++ b/spec/controllers/editorial/nodes_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Editorial::NodesController, type: :controller do
+
+  describe 'GET #index' do
+    let(:section) { Fabricate(:section) }
+    let(:nodes) { Fabricate.times(3, :node, section: section) }
+
+    before do
+      get :index, params: { section: section.slug }
+    end
+
+    it { is_expected.to assign_to(:section).with section }
+    it { is_expected.to assign_to(:nodes).with section.nodes.decorate }
+  end
+
+end

--- a/spec/fabricators/node.rb
+++ b/spec/fabricators/node.rb
@@ -3,4 +3,5 @@ Fabricator(:node) do
   uuid { SecureRandom.uuid }
   template 'default'
   section
+  state 'published'
 end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Node, type: :model do
   it { is_expected.to belong_to :parent }
   it { is_expected.to have_many :children }
   it { is_expected.to have_one :content_block }
+  it { is_expected.to validate_inclusion_of(:state).in_array(
+    ['draft', 'published']) }
 
   describe 'Sibling order' do
 


### PR DESCRIPTION
Users can browse to:
/editorial/:section/nodes 

... to see a list of all nodes. Not yet protected by authorisation (authentication is implemented but not authorisation yet).

However, I haven't linked this from anywhere. Maybe we could link from the toolbar? Thoughts? (Though more useful would be 'show me my drafts' for an author, 'show me drafts for review' for a moderator, and filtering is out of scope... thus I haven't linked it at all, yet.)

Thoughts?
