### PR TITLE
SITES-140 fix

### DIFF
--- a/db/migrate/20160607010429_add_token_to_nodes.rb
+++ b/db/migrate/20160607010429_add_token_to_nodes.rb
@@ -1,6 +1,16 @@
 class AddTokenToNodes < ActiveRecord::Migration[5.0]
-  def change
+  def up
     add_column :nodes, :token, :string, null: false
+
+    Node.all.each do |node|
+      node.update_column :token, SecureRandom.uuid
+    end
+
     add_index :nodes, :token, unique: true
+  end
+
+  def down
+    remove_index :nodes, :token
+    remove_column :nodes, :token
   end
 end


### PR DESCRIPTION
Update existing nodes with token values to avoid migration crashing out when it tries to add a unique constraint to the token column.
