### PR TITLE
Updated css version without sourceMappingURL

### DIFF
--- a/vendor/assets/stylesheets/dto-ui-kit.css
+++ b/vendor/assets/stylesheets/dto-ui-kit.css
@@ -641,6 +641,5 @@ nav ul {
   margin-left: 0;
   padding-left: 0; }
 
-/* git version: 3e61ca45f657e6018b1243cd21f41f07218a225c */
-/* created at: Tue Jun 07 2016 04:23:34 GMT+0000 (UTC)*/
-/*# sourceMappingURL=style.css.map */
+/* git version: e79e4b42ca1e906f00ed59a7afbc2e060a314c65 */
+/* created at: Wed Jun 08 2016 06:19:01 GMT+0000 (UTC)*/


### PR DESCRIPTION
Updated css version without sourceMappingURL which causes spurious 404s in chrome. See https://github.com/AusDTO/gov-au-ui-kit/issues/17.
