### PR TITLE
ensure markup sets the necessary meta data for responsiveness

### DIFF
--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -1,5 +1,6 @@
 <head>
   <title><%= title %></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= csrf_meta_tags %>
 
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
Our markup is currently not setup in the head.html to be responsive:

![screen shot 2016-06-23 at 4 52 52 pm](https://cloud.githubusercontent.com/assets/5369670/16294258/f815a87a-3962-11e6-9f82-e49670bf11a8.png)
![screen shot 2016-06-23 at 4 52 58 pm](https://cloud.githubusercontent.com/assets/5369670/16294257/f814494e-3962-11e6-8e66-1581d0df09fd.png)
