### PR TITLE
Conditionally display request topic link with associated tests

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -1,6 +1,6 @@
 module RequestsHelper
   def show_request_controls?
     return false unless user_signed_in?
-    @section.present? && !current_user.collaborator_on?(@section)
+    @section.present? && @section.is_a?(Topic) && !current_user.collaborator_on?(@section)
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,4 +23,5 @@
     %footer{role: "contentinfo"}
       .wrapper
         %span
-          = link_to('Sign in', new_user_session_path, style: 'color:#fff;') # TODO: No styles for links in footer in UI Kit yet
+          - unless user_signed_in?
+            = link_to('Sign in', new_user_session_path, style: 'color:#fff;') # TODO: No styles for links in footer in UI Kit yet

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'admin features', type: :feature do
 
-  include Warden::Test::Helpers
   Warden.test_mode!
   let!(:admin_user) { Fabricate(:user, is_admin: true) }
 

--- a/spec/features/creating_content_spec.rb
+++ b/spec/features/creating_content_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'creating content:', type: :feature do
-  include Warden::Test::Helpers
   Warden.test_mode!
 
   before :each do

--- a/spec/features/editing_content_spec.rb
+++ b/spec/features/editing_content_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'editing content', type: :feature do
 
-  include Warden::Test::Helpers
   Warden.test_mode!
   let!(:section) { Fabricate(:section) }
   let!(:author) { Fabricate(:user, author_of: section) }

--- a/spec/features/editorial_auth_spec.rb
+++ b/spec/features/editorial_auth_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe 'editorial authorisation' do
-  include Warden::Test::Helpers
   Warden.test_mode!
 
   let!(:section) { Fabricate(:section) }

--- a/spec/features/editorial_navigation_spec.rb
+++ b/spec/features/editorial_navigation_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'editorial navigation:', type: :feature do
 
-  include Warden::Test::Helpers
   Warden.test_mode!
 
   let!(:section1) { Fabricate(:section) }

--- a/spec/features/sections_spec.rb
+++ b/spec/features/sections_spec.rb
@@ -16,5 +16,30 @@ RSpec.describe "section features", :type => :feature do
       visit '/'
       expect(find_link(root.name)[:href]).to eq(section_path(root))
     end
+
+    context 'when signed in' do
+      let (:user) { Fabricate(:user) }
+      before do
+        login_as(user)
+      end
+
+      context 'a topic page' do
+        before do
+          visit section_path(Fabricate(:topic))
+        end
+        it 'shows a request membership link' do
+          expect(page.body).to have_content(/request/i)
+        end
+      end
+
+      context 'an agency page' do
+        before do
+          visit section_path(Fabricate(:agency))
+        end
+        it 'does not show request membership link' do
+          expect(page.body).not_to have_content(/request/i)
+        end
+      end
+    end
   end
 end

--- a/spec/support/warden.rb
+++ b/spec/support/warden.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Warden::Test::Helpers, type: :feature
+end


### PR DESCRIPTION
Also, only display the sign in link if we're not signed in and moved the include of `Warden::Test::Helpers` to a configuration file. 
