### PR TITLE
SITES-210 Add editor.md

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 # Other sources
 source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-sass'
+  gem 'rails-assets-editor.md'
 end
 
 # Core gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,7 @@ GEM
       sprockets-rails (>= 2.0.0)
     rails-assets-bootstrap-sass (3.3.6)
       rails-assets-jquery (>= 1.9.0)
+    rails-assets-editor.md (1.5.0)
     rails-assets-jquery (3.0.0)
     rails-controller-testing (0.1.1)
       actionpack (~> 5.x)
@@ -436,6 +437,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (>= 5.0.0.beta4, < 5.1)
   rails-assets-bootstrap-sass!
+  rails-assets-editor.md!
   rails-controller-testing (~> 0.1.1)
   rails_12factor
   rails_serve_static_assets

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,6 @@
 //= require turbolinks
 //= require simplemde.min
 //= require trumbowyg
+//= require editor.md/editormd
+//= require editor.md/languages/en
 //= require_tree .

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,5 +14,6 @@
  *= require "dto-ui-kit"
  *= require "simplemde.min"
  *= require "trumbowyg.min"
+ *= require "editor.md/scss/editormd"
  *= require_self
  */

--- a/app/views/editorial/nodes/_editor_injection.haml
+++ b/app/views/editorial/nodes/_editor_injection.haml
@@ -10,3 +10,41 @@
     $('#node_content_body').css({'display': 'none'});
     $('#editor').trumbowyg('html', document.getElementById('node_content_body').value);
     $('form').submit(function(event) {document.getElementById('node_content_body').value = $('#editor').trumbowyg('html');});
+
+- if @editor == 'editormd'
+  :javascript
+    $('#node_content_body').wrap('<div id="editormd"></div>');
+    $('#node_content_body').css({'display': 'none'});
+    var editor_md = editormd("editormd",{
+      path : '/assets/editor.md/lib/',
+      placeholder: "Start typing here...",
+      toolbarIcons : function() {
+        return [
+          "undo",
+          "redo",
+          "|",
+          "bold",
+          "italic",
+          "quote",
+          "uppercase",
+          "lowercase",
+          "|",
+          "h1",
+          "h2",
+          "h3",
+          "h4",
+          "|",
+          "list-ul",
+          "list-ol",
+          "hr",
+          "|",
+          "link",
+          "image",
+          "||",
+          "watch",
+          "fullscreen"
+          ];
+        }
+      });
+    $('form').submit(function(event) {editor_md.element.value = editor_md.getMarkdown();});
+

--- a/app/views/editorial/nodes/_editor_links.haml
+++ b/app/views/editorial/nodes/_editor_links.haml
@@ -5,5 +5,8 @@
   - unless @editor == 'trum'
     = link_to 'Try Trumbowyg editor', '?editor=trum'
 
+  - unless @editor == 'editormd'
+    = link_to 'Try Editor.md editor', '?editor=editormd'
+
   - unless @editor.nil?
     = link_to 'Use default editor', edit_editorial_node_path(@node)


### PR DESCRIPTION
Added [editor.md](https://pandao.github.io/editor.md/en.html) another markdown editor like simplemde, but with more features and is extensible. 

Unfortunately I've had to check in lots of files that it needs, as we haven't got bower working yet.

<img width="711" alt="screen shot 2016-06-25 at 2 34 25 pm" src="https://cloud.githubusercontent.com/assets/2324569/16354730/14d0571e-3ae2-11e6-819a-15e65f238d7a.png">
