### PR TITLE
Disable CAS - unlock content authors

### DIFF
--- a/app/forms/node_form.rb
+++ b/app/forms/node_form.rb
@@ -5,5 +5,5 @@ class NodeForm < Reform::Form
 
   #TODO figure out a way to combine these to DRY up future content block declarations
   property :content_body
-  validates :content_body, content_analysis: true
+  #validates :content_body, content_analysis: true #FIXME: restore once we have feedback and/or ability to ignore
 end

--- a/spec/controllers/editorial/nodes_controller_spec.rb
+++ b/spec/controllers/editorial/nodes_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+#FIXME: restore CAS blocks in POST #create below once CAS is restored
+
 RSpec.describe Editorial::NodesController, type: :controller do
   render_views
 
@@ -45,9 +47,9 @@ RSpec.describe Editorial::NodesController, type: :controller do
   end
 
   describe 'POST #create' do
-    before do
-      expect(ContentAnalysisHelper).to receive(:lint).and_return('')
-    end
+    # before do
+    #   expect(ContentAnalysisHelper).to receive(:lint).and_return('')
+    # end
 
     context 'when user is authorised' do
       before { sign_in(author) }
@@ -65,14 +67,14 @@ RSpec.describe Editorial::NodesController, type: :controller do
         expect { subject }.to change(Node, :count).by(1)
       end
     end
-  end
-  describe 'POST #create' do
+
     describe 'to a collaborate node' do
       context 'as authorised user' do
 
-        before do
-          expect(ContentAnalysisHelper).to receive(:lint).and_return('')
-        end
+        # before do
+        #   expect(ContentAnalysisHelper).to receive(:lint).and_return('')
+        # end
+
         before { sign_in(author) }
 
         let(:submission) { Fabricate(:submission) }

--- a/spec/features/creating_content_spec.rb
+++ b/spec/features/creating_content_spec.rb
@@ -39,14 +39,15 @@ RSpec.describe 'creating content:', type: :feature do
       end
     end
 
-    context 'with invalid data' do
-      it 'return to the edit form' do
-        fill_in('Name', with: name)
-        fill_in('Body', with: 'Bad Content')
-        click_button('Create')
-        expect(page).to have_content(/failed.*content.*analysis/i)
-      end
-    end
+    # FIXME: restore this spec once CAS validation is restored
+    # context 'with invalid data' do
+    #   it 'return to the edit form' do
+    #     fill_in('Name', with: name)
+    #     fill_in('Body', with: 'Bad Content')
+    #     click_button('Create')
+    #     expect(page).to have_content(/failed.*content.*analysis/i)
+    #   end
+    # end
 
     it_behaves_like 'robust to XSS'
   end


### PR DESCRIPTION
Quickly and nastily disable CAS so as to unblock content authors from adding content. 
I had to comment out the validator altogether from the form - probably not ideal but I just need to let them add content & CAS is adding no value at the moment as it's just a proof of concept (only one or two rules implemented AFAIK).
