### PR TITLE
Use info level in test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.log_level = :info
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
turns off the verbose active record logging, small speed increase in tests, easier to view on circleci
