### PR TITLE
[SITES-310] Change markdown renderer from kramdown to redcarpet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'cancancan'
 gem 'rolify'
 gem 'storext', github: 'micapam/storext', ref: '3e69a6b6' # force bundle to work (Rails 5)
 gem 'markerb'
-gem 'kramdown'
+gem 'redcarpet'
 gem 'andand'
 gem 'diff-lcs', '~> 1.2.5'
 gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,6 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    kramdown (1.11.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.1.5)
@@ -289,6 +288,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redcarpet (3.3.4)
     refile (0.3.0)
       rest-client (~> 1.7.2)
     reform (2.2.1)
@@ -433,7 +433,6 @@ DEPENDENCIES
   httparty (~> 0.13.0)
   jbuilder (~> 2.0)
   jquery-rails
-  kramdown
   launchy
   markerb
   mini_magick
@@ -449,6 +448,7 @@ DEPENDENCIES
   rails-controller-testing (~> 0.1.1)
   rails_12factor
   rails_serve_static_assets
+  redcarpet
   refile
   reform
   reform-rails

--- a/app/decorators/node_decorator.rb
+++ b/app/decorators/node_decorator.rb
@@ -23,7 +23,8 @@ class NodeDecorator < Draper::Decorator
 
   def content_body
     unless object.content_body.nil?
-      raw = Kramdown::Document.new(object.content_body).to_html.html_safe
+      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)
+      raw = markdown.render(object.content_body)
       ActionController::Base.helpers.sanitize(raw)
     end
   end

--- a/spec/decorators/node_decorator_spec.rb
+++ b/spec/decorators/node_decorator_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe NodeDecorator, type: :decorator do
       it { is_expected.to match('<h1>') }
     end
 
+    context 'renders consecutive headings' do
+      subject { Fabricate(:general_content, content_body: "# Heading\n## Heading 2").decorate.content_body }
+      it { is_expected.to match('<h2>') }
+    end
+
     context 'handles no content' do
       subject { Fabricate(:general_content, content_body: nil).decorate.content_body }
       it { is_expected.to be_blank }


### PR DESCRIPTION
Currently, if an author enters the following:

```
# Heading 1
## Heading 2
```

The preview respects the second heading but kramdown does not. If we change to redcarpet, this is rendered the same in the preview and the published version.
