### PR TITLE
[SITES-311] Process markdown tables

### DIFF
--- a/app/decorators/node_decorator.rb
+++ b/app/decorators/node_decorator.rb
@@ -23,7 +23,7 @@ class NodeDecorator < Draper::Decorator
 
   def content_body
     unless object.content_body.nil?
-      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)
+      markdown = Redcarpet::Markdown.new(ContentMarkdown, tables: true)
       raw = markdown.render(object.content_body)
       ActionController::Base.helpers.sanitize(raw)
     end

--- a/app/services/content_markdown.rb
+++ b/app/services/content_markdown.rb
@@ -1,0 +1,10 @@
+# for more details, see https://github.com/vmg/redcarpet
+class ContentMarkdown < Redcarpet::Render::HTML
+
+  # override the table method to add custom class
+  # super: https://github.com/vmg/redcarpet/blob/master/ext/redcarpet/html.c#L531
+  def table(header, body)
+    "<table class=\"content-table\"><thead>\n#{header}</thead><tbody>\n#{body}</tbody></table>\n"
+  end
+
+end

--- a/app/views/editorial/nodes/_editor_injection.haml
+++ b/app/views/editorial/nodes/_editor_injection.haml
@@ -5,7 +5,7 @@
     function previewMarkdown(){
       var text = $('#node_content_body')[0].value,
         target = $('#editor-preview')[0],
-        converter = new showdown.Converter(),
+        converter = new showdown.Converter({tables: true}),
         html = converter.makeHtml(text);
 
         target.innerHTML = html;

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,11 @@ module GovAuBeta
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Allow tables through the sanitizer
+    config.after_initialize do
+      ActionView::Base.sanitized_allowed_tags.merge(%w{table th tr td thead tbody})
+    end
+
     config.generators do |g|
       g.stylesheets false
       g.javascripts false

--- a/spec/decorators/node_decorator_spec.rb
+++ b/spec/decorators/node_decorator_spec.rb
@@ -3,18 +3,28 @@ require 'rails_helper'
 RSpec.describe NodeDecorator, type: :decorator do
   describe '#content_body' do
 
+    def decorated_body(body)
+      Fabricate(:general_content, content_body: body).decorate.content_body
+    end
+
     context 'renders markdown' do
-      subject { Fabricate(:general_content, content_body: '# Heading').decorate.content_body }
+      subject { decorated_body('# Heading') }
       it { is_expected.to match('<h1>') }
     end
 
     context 'renders consecutive headings' do
-      subject { Fabricate(:general_content, content_body: "# Heading\n## Heading 2").decorate.content_body }
+      subject { decorated_body("# Heading\n## Heading 2") }
       it { is_expected.to match('<h2>') }
     end
 
+    context 'tables' do
+      subject { decorated_body("| h1 | h2 |\n|---|---|\n| c1 | c2 |") }
+      it { is_expected.to have_css('table') }
+      it { is_expected.to have_css('table.content-table') }
+    end
+
     context 'handles no content' do
-      subject { Fabricate(:general_content, content_body: nil).decorate.content_body }
+      subject { decorated_body(nil) }
       it { is_expected.to be_blank }
     end
   end


### PR DESCRIPTION
This enables markdown tables entered in the content editor. Unfortunately, the preview is unformatted because I cannot add the "content-table" class to the `<table>` without modifying showdown itself.
## Preview

![screen shot 2016-07-05 at 5 10 43 pm](https://cloud.githubusercontent.com/assets/4583474/16603542/2442302e-4360-11e6-9380-23b32d98aea8.png)
## Public site

![screen shot 2016-07-06 at 9 58 17 am](https://cloud.githubusercontent.com/assets/4583474/16603551/319d96aa-4360-11e6-963c-2e0bf82a49e6.png)
