### PR TITLE
[SITES-331] Publish nodes on accepting a submission

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -69,6 +69,9 @@ class Submission < ApplicationRecord
     transaction do
       review! by_reviewer, 'accepted'
       revision.apply!
+      # For now, as soon as a submission is accepted, the node is published
+      # This is subject to change as we update workflow
+      revisable.update(state: 'published')
     end
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Submission, type: :model do
 
   describe 'reviewing' do
     let(:reviewer) { Fabricate(:user, reviewer_of: revision.section) }
-    let(:revision) { Fabricate(:node).revise! content_body: 'Revised content' }
+    let(:revision) { Fabricate(:node, state: 'draft').revise! content_body: 'Revised content' }
     subject { Fabricate(:submission, revision: revision, submitted_at: 3.days.ago, state: :submitted) }
 
     before do
@@ -64,6 +64,7 @@ RSpec.describe Submission, type: :model do
       it { expect(subject).to be_rejected }
       it { expect(subject.reviewed_at).to be_present }
       it { expect(revision.revisable.content_body).not_to eq 'Revised content' }
+      it { expect(revision.revisable.state).to eq 'draft' }
     end
 
     context 'acceptance' do
@@ -72,6 +73,7 @@ RSpec.describe Submission, type: :model do
       it { expect(subject).to be_accepted }
       it { expect(subject.reviewed_at).to be_present }
       it { expect(revision.revisable.content_body).to eq 'Revised content' }
+      it { expect(revision.revisable.state).to eq 'published' }
     end
   end
 end


### PR DESCRIPTION
This is not necessarily the ideal workflow but should unblock our current content authors until such time as we implement a better way.
