### PR TITLE
Allow an author to edit node metadata, including child order

### DIFF
--- a/app/controllers/editorial/nodes_controller.rb
+++ b/app/controllers/editorial/nodes_controller.rb
@@ -59,22 +59,17 @@ module Editorial
     end
 
     def edit
-
       @node = Node.find(params[:id])
       authorize! :update, @node
-      @type_name = @node.class.name.underscore
-      @form = "#{@node.class.name}Form".constantize.new(@node)
-      @editor = params[:editor]
-      redirect_to new_editorial_section_submission_path(@section, node_id: @node, editor: @editor)
+      @form = NodeMetadataForm.new(@node)
     end
 
     def update
       @node = Node.find(params[:id])
       authorize! :update, @node
-      @form = new_form(@node)
-
+      @form = NodeMetadataForm.new(@node)
       if try_save
-        redirect_to editorial_node_path(@form)
+        redirect_to editorial_section_node_path(@section, @node)
       else
         render :edit
       end
@@ -103,8 +98,7 @@ module Editorial
 
     def try_save
       return false unless @form.validate(params.require(:node).permit!)
-      @form.sync
-      @form.model.save
+      @form.save
     end
   end
 end

--- a/app/controllers/editorial/submissions_controller.rb
+++ b/app/controllers/editorial/submissions_controller.rb
@@ -34,7 +34,7 @@ module Editorial
       authorize! :review, @submission
       if params[:accept]
         @submission.accept!(current_user)
-        redirect_to nodes_path(section: @submission.section, path: @submission.revisable.path)
+        redirect_to nodes_path(@submission.revisable.path)
       elsif params[:reject]
         @submission.reject!(current_user)
         redirect_to editorial_section_submission_path(@section, @submission)

--- a/app/forms/node_metadata_form.rb
+++ b/app/forms/node_metadata_form.rb
@@ -1,0 +1,7 @@
+class NodeMetadataForm < Reform::Form
+  property :parent_id
+  collection :children do
+    property :name, writable: false
+    property :order_num, validates: {presence: true}
+  end
+end

--- a/app/views/application/_navbar_part.html.haml
+++ b/app/views/application/_navbar_part.html.haml
@@ -4,7 +4,7 @@
   - nodes.each do |node|
     %li
       - klass = 'is-active' if node == active
-      %a{ href: nodes_path(section: node.section, path: node.path), class: klass }
+      %a{ href: nodes_path(node.path), class: klass }
         = node.name
       - if depth > 1
         %ul

--- a/app/views/application/_page_actions.html.haml
+++ b/app/views/application/_page_actions.html.haml
@@ -13,3 +13,5 @@
         = link_to "Open submission (#{@node.submissions.last.submitter.email})", editorial_section_submission_path(@section, @node.submissions.open.last)
     - else
       = link_to 'Edit', new_editorial_section_submission_path(@section, node_id: @node)
+  %li
+    = link_to 'Edit metadata', edit_editorial_section_node_path(@section, @node)

--- a/app/views/editorial/nodes/edit.html.haml
+++ b/app/views/editorial/nodes/edit.html.haml
@@ -1,0 +1,15 @@
+- breadcrumb :edit_editorial_node, @node
+
+%h1
+  Edit #{@form.model.name} metadata
+
+= simple_form_for [:editorial, @form], as: :node, url: editorial_section_node_path(@form.model.section, @form.model)  do |f|
+  = f.input :parent_id, collection: @section.nodes.order(:name), include_blank: true, required: false, selected: @form.parent_id
+  - unless @form.children.empty?
+    %fieldset
+      %legend
+        Child menu order
+      = f.fields_for :children do |child|
+        = child.input :order_num, label: "#{child.object.name}", as: :integer
+  = f.button :button, 'Edit metadata'
+

--- a/app/views/editorial/nodes/show.html.haml
+++ b/app/views/editorial/nodes/show.html.haml
@@ -10,7 +10,7 @@
     = render template: "templates/#{node.template}"
 
 %h2 Metadata
-%table.content-table
+%table.content-table#metadata-table
   %thead
     %tr
       %th Name
@@ -36,7 +36,7 @@
         - else
           none
     %tr
-      %td Sibling order
+      %td Menu order
       %td= node.order_num
     %tr
       %td Slug
@@ -49,7 +49,7 @@
       %td= node.state
 
 %h2 Content history
-%table.content-table
+%table.content-table#history-table
   %thead
     %tr
       %th Submission

--- a/app/views/sections/_menu.html.haml
+++ b/app/views/sections/_menu.html.haml
@@ -2,5 +2,5 @@
   %ul
     - nodes.each do |node|
       %li
-        = link_to(node, nodes_path(section: section, path: node.path))
+        = link_to(node, nodes_path(node.path))
         = render partial: "menu", locals: {nodes: node.children.published, depth: depth += 1, section: section}

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -51,6 +51,11 @@ crumb :new_editorial_node do |section, parent_node, type|
   parent :prepare_editorial_nodes, section, parent_node
 end
 
+crumb :edit_editorial_node do |node|
+  link 'Edit', edit_editorial_section_node_path(node.section, node)
+  parent :editorial_node, node
+end
+
 crumb :editorial_section_submissions do |section|
   link 'Submissions', editorial_section_submissions_path(section)
   parent :editorial_section, section

--- a/spec/controllers/editorial/submissions_controller_spec.rb
+++ b/spec/controllers/editorial/submissions_controller_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Editorial::SubmissionsController, type: :controller do
 
       context '(:accept)' do
         subject { post :update, section_id: submission.section, id: submission.id, accept: true }
-        it { is_expected.to redirect_to nodes_path(section: submission.section, path: submission.revisable.path) }
+        it { is_expected.to redirect_to nodes_path(submission.revisable.path) }
         it 'change to accepted' do
           expect { subject }.to change { submission.reload.accepted? }.from(false).to(true)
         end

--- a/spec/fabricators/section.rb
+++ b/spec/fabricators/section.rb
@@ -1,14 +1,18 @@
 Fabricator(:section) do
   transient :with_home
   name { Fabricate.sequence(:section_name) { |i| "section-#{i}" } }
-  after_create {|section, transients|
+  after_create do |section, transients|
     if transients[:with_home]
+      unless Node.root
+        Fabricate(:root_node)
+      end
       Fabricate(:section_home) do
         section section
         parent Node.root
         name section.name
       end
-    end }
+    end
+  end
 end
 
 Fabricator(:agency) do

--- a/spec/features/editing_content_spec.rb
+++ b/spec/features/editing_content_spec.rb
@@ -51,12 +51,12 @@ RSpec.describe 'editing content', type: :feature do
   end
 
   context 'when editing content' do
-    let!(:section1) { Fabricate(:section) }
-    let!(:section2) { Fabricate(:section) }
+    let!(:section1) { Fabricate(:section, with_home: true) }
+    let!(:section2) { Fabricate(:section, with_home: true) }
     let!(:node1) { Fabricate(:general_content, state: 'published',
-      parent: root_node, section: section1) }
+      parent: section1.home_node) }
     let!(:node2) { Fabricate(:news_article, state: 'published',
-      parent: root_node, section: section2) }
+      parent: section2.home_node) }
 
     before :each do
       author.add_role(:author, section1)
@@ -80,7 +80,7 @@ RSpec.describe 'editing content', type: :feature do
         end
 
         it 'should take the user to the created submission view' do
-          expect(current_path).to match /editorial\/#{node1.section.slug}\/submissions\/\d+/
+          expect(current_path).to match /editorial\/#{node1.section.id}\/submissions\/\d+/
         end
 
         it 'should not update the record directly' do

--- a/spec/features/editing_content_spec.rb
+++ b/spec/features/editing_content_spec.rb
@@ -72,36 +72,29 @@ RSpec.describe 'editing content', type: :feature do
     end
 
     context 'creating a submission' do
-      before do
-        visit new_editorial_section_submission_path(node1.section, node_id: node1)
-        fill_in 'Body', with: 'Brand new content'
-        click_button 'Submit for review'
+      context 'with good content' do
+        before do
+          visit new_editorial_section_submission_path(node1.section, node_id: node1)
+          fill_in 'Body', with: 'Brand new content'
+          click_button 'Submit for review'
+        end
+
+        it 'should take the user to the created submission view' do
+          expect(current_path).to match /editorial\/#{node1.section.slug}\/submissions\/\d+/
+        end
+
+        it 'should not update the record directly' do
+          visit "/#{node1.path}"
+          expect(page).not_to have_content 'Brand new content'
+        end
       end
 
-      it 'should take the user to the created submission view' do
-        expect(current_path).to match /editorial\/#{node1.section.id}\/submissions\/\d+/
+      it_behaves_like 'robust to XSS' do
+        before { visit new_editorial_section_submission_path(node1.section, node_id: node1) }
       end
-
-      it 'should not update the record directly' do
-        visit "/#{node1.path}"
-        expect(page).not_to have_content 'Brand new content'
+      it_behaves_like 'robust to XSS' do
+        before { visit new_editorial_section_submission_path(node2.section, node_id: node2) }
       end
-    end
-
-    context 'with bad content' do
-      it 'should return to the edit form' do
-        visit edit_editorial_section_node_path(node1.section, node1.id)
-        fill_in('Body', with: 'Bad Content')
-        click_button('Submit for review')
-        expect(page).to have_content(/Your changes have been submitted/i)
-      end
-    end
-
-    it_behaves_like 'robust to XSS' do
-      before { visit edit_editorial_section_node_path(node1.section, node1) }
-    end
-    it_behaves_like 'robust to XSS' do
-      before { visit edit_editorial_section_node_path(node2.section, node2) }
     end
   end
 

--- a/spec/features/editing_node_metadata_spec.rb
+++ b/spec/features/editing_node_metadata_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe 'editing node metadata:', type: :feature do
+
+  Warden.test_mode!
+  let!(:section) { Fabricate(:section) }
+  let!(:author) { Fabricate(:user, author_of: section) }
+  let!(:parent) { Fabricate(:general_content, section: section) }
+  let!(:child1) { Fabricate(:general_content, section: section, parent: parent) }
+  let!(:child2) { Fabricate(:general_content, section: section, parent: parent) }
+  let!(:child3) { Fabricate(:general_content, section: section, parent: parent) }
+
+  before :each do
+    login_as(author, scope: :user)
+  end
+
+  after do
+    logout(:user)
+  end
+
+  context 'editing a parent node' do
+    before do
+      visit edit_editorial_section_node_path(section, parent)
+    end
+
+    it 'shows the children order form' do
+      expect(page).to have_css('fieldset')
+      parent.children.each do |child|
+        expect(page).to have_content(child.name)
+      end
+    end
+
+    context 'setting the child order' do
+      it 'sets the child order' do
+        fill_in(child1.name, with: 3)
+        fill_in(child2.name, with: 1)
+        fill_in(child3.name, with: 2)
+        click_button('Edit')
+        expect(page).to have_content(Regexp.new("#{child2.name}.*#{child3.name}.*#{child1.name}"))
+      end
+    end
+
+    context 'setting invalid data' do
+      it 'returns the error' do
+        fill_in(child1.name, with: nil)
+        click_button('Edit')
+        expect(page).to have_content('can\'t be blank')
+      end
+    end
+  end
+
+  context 'editing a child' do
+    before do
+      visit edit_editorial_section_node_path(section, child1)
+    end
+
+    it 'prefills the parent' do
+      expect(page).to have_select('Parent', selected: parent.name)
+    end
+
+    it 'does not show children order form' do
+      expect(page).not_to have_css('fieldset')
+    end
+
+    context 'setting the parent' do
+      it 'sets the parent' do
+        select(child2.name, from: 'Parent')
+        click_button('Edit')
+        expect(page).to have_content(child2.name)
+        expect(page).not_to have_content(parent.name)
+      end
+    end
+  end
+
+end

--- a/spec/features/editing_node_metadata_spec.rb
+++ b/spec/features/editing_node_metadata_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe 'editing node metadata:', type: :feature do
 
   Warden.test_mode!
-  let!(:section) { Fabricate(:section) }
+  let!(:section) { Fabricate(:section, with_home: true) }
   let!(:author) { Fabricate(:user, author_of: section) }
-  let!(:parent) { Fabricate(:general_content, section: section) }
-  let!(:child1) { Fabricate(:general_content, section: section, parent: parent) }
-  let!(:child2) { Fabricate(:general_content, section: section, parent: parent) }
-  let!(:child3) { Fabricate(:general_content, section: section, parent: parent) }
+  let!(:parent) { Fabricate(:general_content, parent: section.home_node) }
+  let!(:child1) { Fabricate(:general_content, parent: parent) }
+  let!(:child2) { Fabricate(:general_content, parent: parent) }
+  let!(:child3) { Fabricate(:general_content, parent: parent) }
 
   before :each do
     login_as(author, scope: :user)
@@ -21,6 +21,10 @@ RSpec.describe 'editing node metadata:', type: :feature do
   context 'editing a parent node' do
     before do
       visit edit_editorial_section_node_path(section, parent)
+    end
+
+    it 'prefills the parent' do
+      expect(page).to have_select('Parent', selected: section.home_node.name)
     end
 
     it 'shows the children order form' do

--- a/spec/support/shared_examples_for_xss.rb
+++ b/spec/support/shared_examples_for_xss.rb
@@ -3,12 +3,13 @@
 RSpec.shared_examples 'robust to XSS' do
   it 'strip the script tags' do
     # FIXME: Really, we should test all of the fields in the content type
-    # Right now when we create a revision we can only change body (DD 20160625)
-    # fill_in('Name', with: 'XSS Attempt')
+    # Right now when we create a revision we can only change body & name (DD 20160625)
+    fill_in('Name', with: 'Good Name<script>alert()</script>')
     fill_in('Body', with: 'Good Content<script>alert()</script>')
     click_button('')
     within('article') do
       expect(page).not_to have_css('script', text: 'alert', visible: false)
+      expect(page).to have_content('Good Name')
       expect(page).to have_content('Good Content')
     end
   end


### PR DESCRIPTION
**DO NOT MERGE UNTIL AFTER #180**

Obviously this is not the best user experience possible but it makes it possible to change node order.

![screen shot 2016-07-12 at 4 39 15 pm](https://cloud.githubusercontent.com/assets/4583474/16757438/66b8bd12-484f-11e6-8d77-c9e63b2e3539.png)
