### PR TITLE
Fix for editorial/nodes/show

### DIFF
--- a/app/controllers/editorial/nodes_controller.rb
+++ b/app/controllers/editorial/nodes_controller.rb
@@ -2,6 +2,7 @@ module Editorial
   class NodesController < Editorial::SectionsController
     include ::NodesHelper, ::EditorialHelper
     decorates_assigned :node
+    decorates_assigned :menu_nodes, with: NodeDecorator
 
     before_action :derive_type, except: [:show, :prepare]
 
@@ -17,6 +18,7 @@ module Editorial
 
     def show
       @node = Node.find(params[:id])
+      set_menu_nodes
     end
 
     def prepare

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -18,12 +18,4 @@ class NodesController < ApplicationController
     set_menu_nodes
     render_node node
   end
-
-  private
-
-  def set_menu_nodes
-    if @section.present? && @section.home_node.present?
-      @menu_nodes = @section.home_node.children.published
-    end
-  end
 end

--- a/app/helpers/nodes_helper.rb
+++ b/app/helpers/nodes_helper.rb
@@ -16,4 +16,10 @@ module NodesHelper
     end
   end
 
+  def set_menu_nodes
+    if @section.present? && @section.home_node.present?
+      @menu_nodes = @section.home_node.children.published
+    end
+  end
+
 end


### PR DESCRIPTION
Recent clashing changes to templates and editorial controllers resulted in editorial/nodes/show throwing an exception (SITES-384). This fixes that. 