### PR TITLE
Fixed resource paths for admin sections

### DIFF
--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -17,7 +17,7 @@ module Admin
     # for more information
 
     def find_resource(param)
-      Department.find_by! slug: param
+      Department.find param
     end
   end
 end

--- a/app/controllers/admin/ministers_controller.rb
+++ b/app/controllers/admin/ministers_controller.rb
@@ -17,7 +17,7 @@ module Admin
     # for more information
 
     def find_resource(param)
-      Minister.find_by! slug: param
+      Minister.find param
     end
   end
 end

--- a/spec/controllers/admin/department_controller_spec.rb
+++ b/spec/controllers/admin/department_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::TopicsController, type: :controller do
 
     let(:department) { Fabricate(:department) }
 
-    subject { Admin::DepartmentsController.new.find_resource(department.slug) }
+    subject { Admin::DepartmentsController.new.find_resource(department.id) }
 
     it { is_expected.to eq(department) }
 

--- a/spec/controllers/admin/ministers_controller_spec.rb
+++ b/spec/controllers/admin/ministers_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::MinistersController, type: :controller do
 
     let(:minister) { Fabricate(:minister) }
 
-    subject { Admin::MinistersController.new.find_resource(minister.slug) }
+    subject { Admin::MinistersController.new.find_resource(minister.id) }
 
     it { is_expected.to eq(minister) }
 


### PR DESCRIPTION
As per: https://govausites.atlassian.net/browse/SITES-391
Fix: updated #find_resource method for admin department and minister controllers.
