### PR TITLE
Dealt with feedback from SITES-355.

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -27,8 +27,8 @@ class Node < ApplicationRecord
   before_validation :generate_token
   before_save :ensure_order_num_present
 
+  validates :parent, non_recursive_ancestry: true
   validates_with RootProtectionValidator
-  validates_with NonRecursiveAncestryValidator
   validates_uniqueness_of :token
 
   def self.find_by_path!(path)

--- a/app/validators/ancestry_depth_validator.rb
+++ b/app/validators/ancestry_depth_validator.rb
@@ -17,6 +17,9 @@ validates :parent, ancestry_depth: { minimum: 1, maximum: 3 }
 
 =end
 class AncestryDepthValidator < ActiveModel::EachValidator
+
+  MAX_DEPTH = 100
+
   def validate_each(record, attribute, value)
     return if record.errors.include? attribute
 
@@ -47,8 +50,10 @@ class AncestryDepthValidator < ActiveModel::EachValidator
   private
 
   def get_depth(record, attribute, depth)
-    if record.send(attribute).present?
-      depth += 1 + get_depth(record.send(attribute), attribute, depth)
+    if depth < MAX_DEPTH
+      if record.send(attribute).present?
+        depth += 1 + get_depth(record.send(attribute), attribute, depth)
+      end
     end
 
     depth

--- a/app/validators/ancestry_depth_validator.rb
+++ b/app/validators/ancestry_depth_validator.rb
@@ -4,6 +4,10 @@ This validator allows one to test the depth of a hierarchical model e.g. a node.
 
 Assumption is that attribute is the ancestry key (e.g. 'parent').
 
+Note: if there is an already an error present on the attribute, validations will
+not be run. This is to avoid recursion in #get_depth in the case of circular
+ancestry (which can be protected against with NonRecursiveAncestryValidator).
+
 You need to supply options for this to validate anything at all. Usage examples:
 
 validates :parent, ancestry_depth: { minimum: 1 }
@@ -12,9 +16,10 @@ validates :parent, ancestry_depth: { equals: 1 }
 validates :parent, ancestry_depth: { minimum: 1, maximum: 3 }
 
 =end
-
 class AncestryDepthValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    return if record.errors.include? attribute
+
     depth = get_depth record, attribute, 0
 
     if options[:maximum].present?

--- a/app/validators/non_recursive_ancestry_validator.rb
+++ b/app/validators/non_recursive_ancestry_validator.rb
@@ -1,12 +1,20 @@
-class NonRecursiveAncestryValidator < ActiveModel::Validator
-  def validate(record)
+=begin
+
+This is a validator for hierarchies to prevent circular ancestry - i.e. where
+the child of a node is also a parent.
+
+Usage example:
+
+validates :parent, non_recursive_ancestry: true
+
+=end
+class NonRecursiveAncestryValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
     node = record
 
-    while node.parent
-      node = node.parent
-
+    while node = node.send(attribute)
       if node == record
-        record.errors.add :parent, 'Circular ancestry is invalid'
+        record.errors.add attribute, 'Circular ancestry is invalid'
         return
       end
     end

--- a/spec/models/general_content_spec.rb
+++ b/spec/models/general_content_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe GeneralContent, type: :model do
-  it { expect(described_class).to be < Node }
+
+  describe 'recursive ancestry' do
+    let!(:root) { Fabricate(:root_node) }
+    let(:section) { Fabricate(:section) }
+    subject(:parent) { Fabricate(:general_content, section: section,
+      parent: section.home_node) }
+    let(:child) { Fabricate(:general_content, section: section,
+      parent: parent) }
+
+    before do
+      parent.parent = child
+    end
+
+    it { is_expected.not_to be_valid }
+
+    # n.b. NonRecursiveAncestryValidator runs first, which stops
+    # AncestryDepthValidator from getting into a recursive tizzy.
+    it 'should not throw an exception when validating' do
+      expect { subject.valid? }.not_to raise_error
+    end
+  end
 end

--- a/spec/validators/non_recursive_ancestry_validator_spec.rb
+++ b/spec/validators/non_recursive_ancestry_validator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 class NonRecursiveAncestryValidatable
   include ActiveModel::Validations
   attr_accessor :parent
-  validates_with NonRecursiveAncestryValidator
+  validates :parent, non_recursive_ancestry: true
 
   def initialize(parent)
     @parent = parent


### PR DESCRIPTION
Validations were tested separately, but on the actual model, if you set a circular ancestry, the ancestry_depth validation would overflow. I've fixed that and introduced a spec on one of the concrete node types (GeneralContent).

See notes on https://govausites.atlassian.net/browse/SITES-355 