### PR TITLE
[SITES-425] - Correctly determine if a node with a given name exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is influenced by http://keepachangelog.com/.
 
 - Add ability to add news articles from /editorial/news
 - Provide link to add news to control bar
+- Added scopes to query nodes based on json items
 
 ### Changed
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -14,6 +14,23 @@ class Node < ApplicationRecord
 
   scope :published, -> { where state: 'published' }
 
+  # These methods aren't DRY to avoid inserting
+  # unescaped strings directly into a PG query.
+  #
+  # This type of query requires the store column to be
+  # unescaped.
+  scope :with_content_value, -> (field, value) {
+    where("content ->> ? = ?", field, value)
+  }
+
+  scope :with_data_value, -> (field, value) {
+    where("data ->> ? = ?", field, value)
+  }
+
+  scope :with_name, -> (name) {
+    with_content_value(:name, name)
+  }
+
   belongs_to :section
   has_many :submissions, through: :revisions
 

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -154,4 +154,22 @@ RSpec.describe Node, type: :model do
       end
     end
   end
+
+  describe '#with_name' do
+    let!(:node1) { Fabricate(:node, name: 'one') }
+    let!(:node2) { Fabricate(:node, name: 'two') }
+    let!(:node3) { Fabricate(:node, name: 'two') }
+
+    it 'returns one element if name is unique' do
+      expect(Node.with_name('one')).to match_array([node1])
+    end
+
+    it 'returns all elements if name is not unique' do
+      expect(Node.with_name('two')).to match_array([node2, node3])
+    end
+
+    it 'returns no elements if name is unknown' do
+      expect(Node.with_name('three')).to match_array([])
+    end
+  end
 end


### PR DESCRIPTION
Note: using find_by for name on a Node object actually queries the name column rather than `content[:name]`.