### PR TITLE
Static categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ This file is influenced by http://keepachangelog.com/.
 - Support for PaaS instance of govCMS
 - Ability to edit page order
 - Give user option to update page parent
+- Ministers index page
+- Infrastructure and Telecommunications category (static)
+- Categories (static) shown on the homepage
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is influenced by http://keepachangelog.com/.
 - Added scopes to query nodes based on json items
 - Ministers index page
 - Infrastructure and Telecommunications category (static)
+- Categories (static) shown on the homepage
 
 ### Changed
 
@@ -64,9 +65,6 @@ This file is influenced by http://keepachangelog.com/.
 - Support for PaaS instance of govCMS
 - Ability to edit page order
 - Give user option to update page parent
-- Ministers index page
-- Infrastructure and Telecommunications category (static)
-- Categories (static) shown on the homepage
 
 ### Changed
 

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -14,13 +14,10 @@ class NodesController < ApplicationController
 
   def home
     @news = NewsArticle.published.limit(8).all
-
     @ministers = Minister.all
-
     @departments = Department.all
-
     @agencies = Agency.all
-
+    @categories = STATIC_CATEGORIES #TODO Replace once categories are proper data
     show
   end
 

--- a/app/views/templates/root_node.html.haml
+++ b/app/views/templates/root_node.html.haml
@@ -5,13 +5,13 @@
   %h2 Information and services
 
   %ul.list-vertical--thirds.home
-    - Topic.all.order(:name).each do |topic|
+    - @categories.each do |category|
       %li
         %article
           %h3
-            = link_to(topic.name, nodes_path(section: topic, path: topic.home_node.path))
+            = link_to(category.name, category.path || 'javascript:void(0)')
           %p
-            = topic.summary
+            = category.summary
 
   %h2.home-heading About Australia
 

--- a/config/categories.yml
+++ b/config/categories.yml
@@ -1,0 +1,66 @@
+- name: Business and industry
+  summary: >
+    ABNs, grants, non-profit and small business, primary industry, import and
+    export, tenders.
+- name: Crime, justice and the law
+  summary: >
+    Consumer protection, fraud, online safety, scams, emergency services,
+    legislation, police, rights.
+- name: Culture, sport and the arts
+  summary: >
+    Indigenous heritage and history, arts grants, cultural institutions, honours
+    and awards, family history.
+- name: Education
+  summary: >
+    Early childhood, school, higher education, international students,
+    skills recognition, scholarships, VET.
+- name: Emergencies and disasters
+  summary: >
+    Triple Zero (000), natural disasters, search and rescue, disaster
+    assistance, health emergencies.
+- name: Environment and agriculture
+  summary: >
+    Energy efficiency, environmental management and protection, biodiversity,
+    grants, natural resources.
+- name: Health and family
+  summary: >
+    Workplace health and safety, drug and alcohol use, health insurance,
+    children's health, mental health, sport.
+- name: Immigration, visas and citizenship
+  summary: >
+    Australian citizenship, customs, work, study and short-term visas, migration
+    and tourism.
+- name: Infrastructure and telecommunications
+  summary: >
+    Regional development, transport safety, Television (TV) reception, internet,
+    telecommunications.
+  path: /categories/infrastructure-and-telecommunications
+- name: Jobs and work
+  summary: >
+    Careers, government jobs, employment services, disability employment,
+    working conditions.
+- name: Money, tax and super
+  summary: >
+    Tax returns, ABNs, superannuation, personal finance, financial regulation.
+- name: Science
+  summary: >
+    Science grants and awards, Chief Scientist, National Measurement Institute,
+    radioactive waste, space.
+- name: Security and defence
+  summary: >
+    National security, cyber security, ADF, military history, commemoration.
+- name: Trade and international
+  summary: >
+    Importing, exporting, free trade agreements, wildlife trade, economic
+    diplomacy, foreign investment, foreign aid.
+- name: Travelling overseas
+  summary: >
+    Customs and quarantine, embassies and consulates, travelling overseas.
+- name: About Australia
+  summary: >
+    Intergenerational report, currency, National archives collection, Australian
+    honours, the constitution.
+- name: About Government
+  summary: >
+    Government structure, freedom of information, elections and voting, Budget,
+    Australian Public Service.

--- a/config/initializers/categories.rb
+++ b/config/initializers/categories.rb
@@ -1,0 +1,4 @@
+hashes = YAML.load_file(Rails.root.join('config/categories.yml'))
+STATIC_CATEGORIES = hashes.collect do |hash|
+  OpenStruct.new hash
+end

--- a/spec/features/home_page.rb
+++ b/spec/features/home_page.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'home page', type: :feature do
+
+  Warden.test_mode!
+
+  let!(:root_node) { Fabricate(:root_node) }
+
+  before do
+    visit root_path
+  end
+
+  describe 'categories' do
+    it { expect(page).to have_link('Infrastructure and telecommunications',
+      href: '/infrastructure-and-telecommunications') }
+  end
+end


### PR DESCRIPTION
Static categories on the homepage as per the prototype. 
I've put the category info into a YAML file which populates an array of OpenStruct objects - so we should later be able to swap out the static data for model instances (once we implement categories in the DB).