### PR TITLE
fix viewing news tags on article pages

### DIFF
--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -17,5 +17,5 @@ Announcements, media releases, interviews, speeches and more from the Australian
             %dl
               %dt
                 Topics:
-                - article.sections.each do |section|
-                  %dd= link_to section.name, section.home_node.full_path
+              - article.sections.each do |section|
+                %dd= link_to section.name, section.home_node.full_path

--- a/app/views/templates/news_article.html.haml
+++ b/app/views/templates/news_article.html.haml
@@ -1,9 +1,10 @@
 %article#content{class: "content-main", tabindex: "-1"}
   - breadcrumb :public_news_article, node
 
-  %ul.tags
-    - node.sections.each do |distribution|
-      %li= distribution.name
+  %dl.list-horizontal
+    %div.tags
+      - node.sections.each do |distribution|
+        %dd= link_to distribution.name, distribution.home_node.full_path
 
   %h1
     =node.name


### PR DESCRIPTION
Fixes the view of the distribution tags on news articles to look right:

![image](https://cloud.githubusercontent.com/assets/5369670/17011463/b95ab4d6-4f51-11e6-881e-78bde691a88c.png)

Also improved the semantic markup for the `/news` page's usage of definition lists.