### PR TITLE
Feature/public holiday pages [SITES-407]

### DIFF
--- a/app/assets/stylesheets/_calendar-callout.scss
+++ b/app/assets/stylesheets/_calendar-callout.scss
@@ -1,0 +1,29 @@
+.callout--calendar-event {
+  background-color: $lighter-aqua;
+  padding: $small-spacing $base-spacing $base-spacing;
+  margin: 2 * $base-spacing 0;
+
+  time,
+  .event-name {
+    @extend h2;
+    margin: 0;
+  }
+
+  time {
+    display: block;
+    font-weight: 700;
+  }
+
+  .event-name {
+    font-weight: 300;
+  }
+
+  .next-event {
+    font-size: rem(16);
+    font-weight: 300;
+  }
+
+  p {
+    margin-top: 0;
+  }
+}

--- a/app/assets/stylesheets/_calendar-table.scss
+++ b/app/assets/stylesheets/_calendar-table.scss
@@ -1,0 +1,60 @@
+.calendar-table {
+  width: 100%;
+  margin-top: 2 * $base-spacing;
+
+  caption {
+    @extend h3;
+    margin: 0 0 $small-spacing;
+    text-align: left;
+  }
+
+  tr {
+    border-bottom: .8 * $tiny-spacing solid $white;
+  }
+
+  th {
+    color: $aqua;
+    display: block;
+    padding: $small-spacing $base-spacing;
+    text-transform: uppercase;
+    width: 100%;
+
+    @include media($mobile) {
+      display: table-cell;
+      width: 6 * $base-spacing;
+    }
+
+    span {
+      @extend h2;
+      display: block;
+      margin: 0;
+    }
+  }
+
+  td {
+    display: block;
+    @extend h4;
+    margin: 0;
+    padding: 0 $base-spacing $small-spacing;
+    text-align: center;
+
+    @include media($mobile) {
+      border-left: .5 * $tiny-spacing solid $white;
+      display: table-cell;
+      padding-top: $small-spacing;
+      text-align: left;
+    }
+
+    .date-info {
+      @extend p;
+      display: block;
+      font-weight: 300;
+      margin-top: 0;
+    }
+  }
+
+  th,
+  td {
+    background-color: $background-secondary-colour;
+  }
+}

--- a/app/assets/stylesheets/_calendar-table.scss
+++ b/app/assets/stylesheets/_calendar-table.scss
@@ -3,7 +3,8 @@
   margin-top: 2 * $base-spacing;
 
   caption {
-    @extend h3;
+    font-size: rem(24);
+    font-weight: 700;
     margin: 0 0 $small-spacing;
     text-align: left;
   }
@@ -46,7 +47,7 @@
     }
 
     .date-info {
-      @extend p;
+      font-size: rem(16);
       display: block;
       font-weight: 300;
       margin-top: 0;

--- a/app/assets/stylesheets/_sort-tabs.scss
+++ b/app/assets/stylesheets/_sort-tabs.scss
@@ -1,0 +1,42 @@
+.sort-container {
+  border-bottom: 1px solid $aqua;
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  font-size: rem(14);
+
+  @include media($mobile) {
+    margin-bottom: 1rem;
+  }
+
+  span {
+    color: $grey;
+    margin-right: 1rem;
+  }
+
+  ul {
+    display: inline;
+    padding-left: 0;
+    margin-bottom: 0;
+
+    li {
+      display: inline;
+    //  margin-left: .25 * $small-spacing;
+    margin-left: 0;
+      margin-bottom: 0;
+      padding-left: 0;
+    }
+
+    a {
+      color: $grey;
+      border-bottom: none;
+      padding:0 1 * $small-spacing 1.07rem;
+      font-size: rem(14);
+    }
+
+    .active {
+      color: $aqua;
+      font-weight: 700;
+      border-bottom: 4px solid;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,6 @@
  @import "page_controls";
  @import "tab";
  @import "homepage";
+ @import "calendar-table";
+ @import "calendar-callout";
+ @import "sort-tabs";

--- a/app/views/templates/custom/public_holidays_qld.html.erb
+++ b/app/views/templates/custom/public_holidays_qld.html.erb
@@ -18,7 +18,7 @@
   </ul>
   </div>
 
-  <section class="callout--event">
+  <section class="callout--calendar-event">
   <h2 class="next-event">The next public holiday is:</h2>
   <p><time class="holiday-date" datetime="">Monday 3rd October </time><span class="event-name">Queen's Birthday</span></p>
   </section>

--- a/app/views/templates/custom/public_holidays_qld.html.erb
+++ b/app/views/templates/custom/public_holidays_qld.html.erb
@@ -1,1 +1,199 @@
-Coming soon - public holidays for Queensland
+<article class="content-main" id="content" role="main">
+
+  <h1>Australian Public holidays</h1>
+
+  <p class="abstract no-border">What state or territory are you in?</p>
+
+  <div class="sort-container">
+  <span>View by:</span>
+  <ul class="news-sort-tabs">
+  <li><a href="/dates-times/public-holidays-nsw.html">NSW</a></li>
+  <li><a href="javascript:void(0)">Vic.</a></li>
+  <li><a href="/times-and-dates/australian-public-holidays/queensland" class="active">Qld</a></li>
+  <li><a href="javascript:void(0)">SA</a></li>
+  <li><a href="javascript:void(0)">WA</a></li>
+  <li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
+  <li><a href="javascript:void(0)">NT</a></li>
+  <li><a href="javascript:void(0)">ACT</a></li>
+  </ul>
+  </div>
+
+  <section class="callout--event">
+  <h2 class="next-event">The next public holiday is:</h2>
+  <p><time class="holiday-date" datetime="">Monday 3rd October </time><span class="event-name">Queen's Birthday</span></p>
+  </section>
+
+  <table class="calendar-table">
+
+  <caption>2016 public holidays</caption>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-01-01T08:00:00+10:00">Friday <span>1</span> January</time>
+      </th>
+      <td>New Year's Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-01-26T08:00:00+10:00">Tuesday <span>26</span> January</time>
+      </th>
+      <td>Australia Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-03-25T08:00:00+10:00">Friday <span>25</span> March</time>
+      </th>
+      <td>Good Friday</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-03-26T08:00:00+10:00">Friday <span>26</span> March</time>
+      </th>
+      <td>Easter Saturday</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-03-28T08:00:00+10:00">Monday <span>28</span> March</time>
+      </th>
+      <td>Easter Monday</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-04-25T08:00:00+10:00">Monday <span>25</span> April</time>
+      </th>
+      <td>Anzac Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-05-02T08:00:00+10:00">Monday <span>2</span> May</time>
+      </th>
+      <td>Labour Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-08-10T08:00:00+10:00">Wednesday <span>10</span> August</time>
+      </th>
+      <td>Royal Queensland Show <span class="date-info">Only in the Brisbane area.</span></td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-10-03T08:00:00+10:00">Monday <span>3</span> October</time>
+      </th>
+      <td>Queen's Birthday</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-12-25T08:00:00+10:00">Sunday <span>25</span> December</time>
+      </th>
+      <td>Christmas Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-04-26T08:00:00+10:00">Monday <span>26</span> December</time>
+      </th>
+      <td>Boxing Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2016-04-27T08:00:00+10:00">Tuesday <span>27</span> December</time>
+      </th>
+      <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
+    </tr>
+
+  </table>
+
+  <table class="calendar-table">
+
+    <caption>2017 public holidays</caption>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-01-01T08:00:00+10:00">Sunday <span>1</span> January</time>
+      </th>
+      <td>New Year's Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-01-02T08:00:00+10:00">Monday <span>2</span> January</time>
+      </th>
+      <td>New Year's Day public holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-01-26T08:00:00+10:00">Thursday <span>26</span> January</time>
+      </th>
+      <td>Australia Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-04-14T08:00:00+10:00">Friday <span>14</span> April</time>
+      </th>
+      <td>Good Friday</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-04-15T08:00:00+10:00">Saturday <span>15</span> April</time>
+      </th>
+      <td>Easter Saturday</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-04-17T08:00:00+10:00">Monday <span>17</span> April</time>
+      </th>
+      <td>Easter Monday</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-04-25T08:00:00+10:00">Tuesday <span>25</span> April</time>
+      </th>
+      <td>Anzac Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-05-01T08:00:00+10:00">Tuesday <span>1</span> May</time>
+      </th>
+      <td>Labour Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-10-02T08:00:00+10:00">Monday <span>2</span> October</time>
+      </th>
+      <td>Queen's Birthday</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-12-25T08:00:00+10:00">Monday <span>25</span> December</time>
+      </th>
+      <td>Christmas Day</td>
+    </tr>
+
+    <tr>
+      <th scope="row">
+        <time datetime="2017-12-26T08:00:00+10:00">Tuesday <span>26</span> December</time>
+      </th>
+      <td>Boxing Day</td>
+    </tr>
+
+  </table>
+
+</article>

--- a/app/views/templates/custom/public_holidays_tas.html.erb
+++ b/app/views/templates/custom/public_holidays_tas.html.erb
@@ -1,1 +1,269 @@
-Coming soon - public holidays for Tasmania
+<article class="content-main" id="content" role="main">
+
+<h1>Australian Public holidays</h1>
+
+<p class="abstract">What state or territory are you in?</p>
+
+<div class="sort-container">
+<span>View by:</span>
+<ul class="news-sort-tabs">
+<li><a href="/dates-times/public-holidays-nsw.html">NSW</a></li>
+<li><a href="javascript:void(0)">Vic.</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/queensland">Qld</a></li>
+<li><a href="javascript:void(0)">SA</a></li>
+<li><a href="javascript:void(0)">WA</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/tasmania" class="active">Tas.</a></li>
+<li><a href="javascript:void(0)">NT</a></li>
+<li><a href="javascript:void(0)">ACT</a></li>
+</ul>
+</div>
+
+<section class="callout--event">
+<h2 class="next-event">The next public holiday is:</h2>
+<p><time datetime="2016-12-25T08:00:00+10:00">Sunday 25 December </time><span class="event-name">Christmas day</span></p>
+</section>
+
+<table class="calendar-table">
+
+<caption>2016 public holidays</caption>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-01T08:00:00+10:00">Friday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-06T08:00:00+10:00">Wednesday <span>6</span> January</time>
+    </th>
+    <td>Devonport Cup <span class="date-info">From 11:00 am in Devonport</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-26T08:00:00+10:00">Tuesday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-02-08T08:00:00+10:00">Monday <span>8</span> February</time>
+    </th>
+    <td>Royal Hobart Regatta <span class="date-info">Only in Hobart, Oatlands and Swansea.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-14T08:00:00+10:00">Monday <span>14</span> March</time>
+      </th>
+    <td>Eight Hours Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-25T08:00:00+10:00">Friday <span>25</span> March</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-28T08:00:00+10:00">Monday <span>28</span> March</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-29T08:00:00+10:00">Tuesday <span>29</span> March</time>
+    </th>
+    <td>Easter Tuesday</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-04-25T08:00:00+10:00">Monday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-06-13T08:00:00+10:00">Monday <span>13</span> June</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-25T08:00:00+10:00">Sunday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-04-26T08:00:00+10:00">Monday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2016-04-27T08:00:00+10:00">Tuesday <span>27</span> December</time>
+    </th>
+    <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
+
+</table>
+
+<table class="calendar-table">
+
+  <caption>2017 public holidays</caption>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-01T08:00:00+10:00">Sunday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-02T08:00:00+10:00">Monday <span>2</span> January</time>
+    </th>
+    <td>New Year's Day public holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-11T08:00:00+10:00">Wednesday <span>11</span> January</time>
+    </th>
+    <td>Devonport Cup <span class="date-info">From 11:00 am in Devonport</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-26T08:00:00+10:00">Thursday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-02-13T08:00:00+10:00">Monday <span>13</span> February</time>
+    </th>
+    <td>Royal Hobart Regatta <span class="date-info">Only in Hobart, Oatlands and Swansea.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-02-22T08:00:00+10:00">Wednesday <span>22</span> February</time>
+    </th>
+    <td>Launceston Cup <span class="date-info">All day in Break O'Day, Dorset, George Town, Glamorgan Spring Bay (north of) and Cranbrook.<br>From 11:00am in Launceston City centre and other suburbs and towns. </span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-03-07T08:00:00+10:00">Tuesday <span>7</span> March</time>
+    </th>
+    <td>King Island Show <span class="date-info">Only on King Island.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-03-13T08:00:00+10:00">Monday <span>13</span> March</time>
+    </th>
+    <td>Eight Hours Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-14T08:00:00+10:00">Friday <span>14</span> April</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-17T08:00:00+10:00">Monday <span>17</span> April</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-18T08:00:00+10:00">Tuesday <span>18</span> April</time>
+    </th>
+    <td>Easter Tuesday</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-25T08:00:00+10:00">Tuesday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-06-12T08:00:00+10:00">Monday <span>12</span> June</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-10-06T08:00:00+10:00">Friday <span>6</span> October</time>
+    </th>
+    <td>Burnie Show <span class="date-info">Only in Burnie, Waratah, Wynyard and West Coast.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-10-12T08:00:00+10:00">Thursday <span>12</span> October</time>
+    </th>
+    <td>Royal Launceston Show <span class="date-info">Only in Break O'Day, Dorset, George Town, Launceston, Meander Valley, Northern Midlands and West Tamar.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-10-20T08:00:00+10:00">Friday <span>20</span> October</time>
+    </th>
+    <td>Flinders Island Show <span class="date-info">Only on Flinders Island.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-11-06T08:00:00+10:00">Monday <span>6</span> November</time>
+    </th>
+    <td>Recreation Day <span class="date-info">Only in areas that don’t have a public holiday for the Royal Hobart Regatta.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-01T08:00:00+10:00">Friday <span>1</span> December</time>
+    </th>
+    <td>Devonport Show <span class="date-info">Only in Devonport, Kentish and Latrobe.</span></td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-25T08:00:00+10:00">Monday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
+
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-26T08:00:00+10:00">Tuesday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
+
+</table>
+
+</article>

--- a/app/views/templates/custom/public_holidays_tas.html.erb
+++ b/app/views/templates/custom/public_holidays_tas.html.erb
@@ -18,7 +18,7 @@
 </ul>
 </div>
 
-<section class="callout--event">
+<section class="callout--calendar-event">
 <h2 class="next-event">The next public holiday is:</h2>
 <p><time datetime="2016-12-25T08:00:00+10:00">Sunday 25 December </time><span class="event-name">Christmas day</span></p>
 </section>


### PR DESCRIPTION
This PR adds static versions of Public holidays pages for Tasmania and Queensland as well as the required css. All 3 components on the page have custom css as they are not yet in the UI Kit.

Sort tabs - This feature is in UI Kit current sprint (https://github.com/AusDTO/gov-au-ui-kit/issues/147)
Calendar callout - I have sent a PR for this to UI Kit (https://github.com/AusDTO/gov-au-ui-kit/pull/191)
Calendar table - I have sent a PR for this to UI Kit (https://github.com/AusDTO/gov-au-ui-kit/pull/190)

![time-dates](https://cloud.githubusercontent.com/assets/12635736/17012683/b435bc48-4f5c-11e6-85be-8da94ea9eef6.png)
