### PR TITLE
remove published scope which was messing with RootNode resolution

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -6,7 +6,7 @@ class NodesController < ApplicationController
 
   def show
 
-    @node = Node.published.find_by_path! params[:path] || ''
+    @node = Node.find_by_path! params[:path] || ''
 
     raise ActiveRecord::RecordNotFound unless can? :read, @node
     @section = @node.section

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -122,7 +122,7 @@ class Node < ApplicationRecord
   end
 
   def self.root_node
-    return Node.find_by(type: 'RootNode')
+    return RootNode.first
   end
 
   private


### PR DESCRIPTION
Removes the published scope to make RootNode.first work as intended.