### PR TITLE
[SITES-364] Fix/news published details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ This file is influenced by http://keepachangelog.com/.
 - Ministers index page
 - Infrastructure and Telecommunications category (static)
 - Categories (static) shown on the homepage
-- Provided aggregate list of news from `/news`
+- Provided aggregate list of news from /news
 - Added a node type for nodes with custom templates
+- Added list of available custom template files when creating a custom template node
+- Added published_at field to all pages
+
 
 ### Changed
 
@@ -22,6 +25,9 @@ This file is influenced by http://keepachangelog.com/.
 - News articles can now be created without a parent
 - Nodes can now specify a layout to override with
 - Removed news article from the node creation prepare select box
+- Moved breadcrumbs above hero banner
+- Changed Table of Contents heading to 'On this page'
+- News Articles get sorted by published_at date
 
 ### Fixed
 

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -5,7 +5,7 @@ class NewsController < ApplicationController
 
 
   def index
-    @articles = NewsArticle.published.by_release_date.by_name
+    @articles = NewsArticle.published.by_release_date.by_published_at.by_name
   end
 
 

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -5,7 +5,7 @@ class NewsController < ApplicationController
 
 
   def index
-    @articles = NewsArticle.published.by_release_date.by_published_at.by_name
+    @articles = NewsArticle.published.by_release_date.by_published_at
   end
 
 

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -12,6 +12,10 @@ class NewsArticle < Node
     order("data ->> 'release_date' DESC")
   }
 
+  scope :by_published_at, -> {
+    order(published_at: :desc)
+  }
+
   scope :by_name, -> {
     order("content ->> 'name' ASC")
   }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -79,7 +79,7 @@ class Submission < ApplicationRecord
       revision.apply!
       # For now, as soon as a submission is accepted, the node is published
       # This is subject to change as we update workflow
-      revisable.update(state: 'published')
+      revisable.update(state: 'published', published_at: Time.now.utc)
     end
   end
 

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -15,7 +15,5 @@ Announcements, media releases, interviews, speeches and more from the Australian
             #{article.short_summary}
           %footer.tags
             %dl
-              %dt
-                Topics:
               - article.sections.each do |section|
                 %dd= link_to section.name, section.home_node.full_path

--- a/db/migrate/20160722043604_add_published_at_datetime_to_node.rb
+++ b/db/migrate/20160722043604_add_published_at_datetime_to_node.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtDatetimeToNode < ActiveRecord::Migration[5.0]
+  def change
+    add_column :nodes, :published_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160721055810) do
+ActiveRecord::Schema.define(version: 20160722043604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,15 +44,16 @@ ActiveRecord::Schema.define(version: 20160721055810) do
     t.string   "name"
     t.string   "slug"
     t.integer  "order_num"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.text     "type"
     t.jsonb    "data"
-    t.string   "state",       default: "draft", null: false
+    t.string   "state",        default: "draft", null: false
     t.string   "token"
     t.string   "cms_url"
     t.string   "cms_api_url"
     t.jsonb    "content"
+    t.datetime "published_at"
     t.index ["parent_id", "slug"], name: "index_nodes_on_parent_id_and_slug", unique: true, using: :btree
     t.index ["parent_id"], name: "index_nodes_on_parent_id", using: :btree
     t.index ["section_id"], name: "index_nodes_on_section_id", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 
 require 'synergy/cms_import'
 
-RootNode.create state: 'published'
+RootNode.create state 'published'
 
 topic = Topic.find_or_create_by!(name: "Business")
 topic.summary = 'The business section covers a range of business-related topics.'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 
 require 'synergy/cms_import'
 
-RootNode.create state 'published'
+RootNode.create state: 'published'
 
 topic = Topic.find_or_create_by!(name: "Business")
 topic.summary = 'The business section covers a range of business-related topics.'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,6 @@ news1 = NewsArticle.with_name(
   ).find_or_create_by!(
     {
       section: topic,
-      parent: news.home_node,
       state: :published,
     }
   ) do |news_article|

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -31,11 +31,15 @@ RSpec.describe NewsController, type: :controller do
 
   describe 'GET #index' do
     let!(:article_unpub) { Fabricate(:news_article, state: 'draft') }
+    let(:in_the_past) { 10.minutes.ago }
     let!(:article_today_a) {
-      Fabricate(:news_article, state: 'published', release_date: Date.today, name: 'A')
+      Fabricate(:news_article, state: 'published', release_date: Date.today, name: 'A', published_at: in_the_past)
     }
     let!(:article_today_b) {
-      Fabricate(:news_article, state: 'published', release_date: Date.today, name: 'B')
+      Fabricate(:news_article, state: 'published', release_date: Date.today, name: 'B', published_at: in_the_past)
+    }
+    let!(:article_today_c) {
+      Fabricate(:news_article, state: 'published', release_date: Date.today, name: 'C', published_at: Time.now.utc)
     }
     let!(:article_yesterday) { Fabricate(:news_article, state: 'published', release_date: Date.yesterday) }
 
@@ -49,7 +53,7 @@ RSpec.describe NewsController, type: :controller do
       end
 
       it 'should return a list ordered by date and name' do
-        expect(assigns(:articles).to_a).to eq([article_today_a, article_today_b, article_yesterday])
+        expect(assigns(:articles).to_a).to eq([article_today_c, article_today_a, article_today_b, article_yesterday])
       end
     end
   end


### PR DESCRIPTION
Addresses comments left on SITES-364, specifically:

* Lets add a published_at to Node
* Order by published_at desc on news index page
* Remove the "Topics" text preceding the section labels