### PR TITLE
SITES-418 `public_node_path` helper

### DIFF
--- a/app/controllers/editorial/news_controller.rb
+++ b/app/controllers/editorial/news_controller.rb
@@ -1,5 +1,6 @@
 module Editorial
   class NewsController < EditorialController
+    include ::NodesHelper
     before_action :set_sections_by_membership, only: [:index, :new, :create, :edit]
 
     def index
@@ -79,7 +80,7 @@ module Editorial
             @node.save!
           end
 
-          redirect_to @node.full_path
+          redirect_to public_node_path(@node)
           return
         end
       end

--- a/app/controllers/editorial/submissions_controller.rb
+++ b/app/controllers/editorial/submissions_controller.rb
@@ -1,6 +1,7 @@
 module Editorial
   class Editorial::SubmissionsController < Editorial::SectionsController
     include ::EditorialHelper
+    include ::NodesHelper
 
     before_action :find_node, only: [:new, :create]
     before_action :check_submission_validity, only: [:new, :create]
@@ -34,7 +35,7 @@ module Editorial
       authorize! :review, @submission
       if params[:accept]
         @submission.accept!(current_user)
-        redirect_to @submission.revisable.full_path
+        redirect_to public_node_path(@submission.revisable)
       elsif params[:reject]
         @submission.reject!(current_user)
         redirect_to editorial_section_submission_path(@section, @submission)

--- a/app/helpers/nodes_helper.rb
+++ b/app/helpers/nodes_helper.rb
@@ -12,4 +12,7 @@ module NodesHelper
     end
   end
 
+  def public_node_path(node)
+    Rails.application.routes.url_helpers.nodes_path(path: node.path)
+  end
 end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -38,10 +38,9 @@ class NewsArticle < Node
   # is not defined by node hierarchy. As such, this method is a convenience
   # wrapper around the url helpers, to allow this model to override the default
   # redirect action.
-  def full_path
-    Rails.application.routes.url_helpers.news_article_path(section.home_node.slug, slug)
+  def path_elements
+    [section.home_node.slug, 'news', slug]
   end
-
 
   # http://norman.github.io/friendly_id/file.Guide.html#Column_or_Method_
   # As we want to scope the friendly_ids to both section and release_date,

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -114,23 +114,16 @@ class Node < ApplicationRecord
     end
   end
 
-  # This is a convenience wrapper around the url helper which defaults to
-  # routing based on the node hierarchy. Other models which inherit from this
-  # may need to define their own route that is not based on this.
-  def full_path
-    Rails.application.routes.url_helpers.nodes_path(path)
-  end
-
   def self.root_node
     return RootNode.first
   end
 
   private
 
+  # Override this method in subclasses to have different routes per subclass.
   def path_elements
     self_and_ancestors.reverse.collect(&:slug)
   end
-
 
   def ensure_order_num_present
     unless order_num.present?

--- a/app/views/application/_navbar_part.html.haml
+++ b/app/views/application/_navbar_part.html.haml
@@ -4,7 +4,7 @@
   - nodes.each do |node|
     %li
       - klass = 'is-active' if node == active
-      %a{ href: nodes_path(node.path), class: klass }
+      %a{ href: public_node_path(node), class: klass }
         = node.name
       - if depth > 1
         %ul

--- a/app/views/departments/index.html.haml
+++ b/app/views/departments/index.html.haml
@@ -5,8 +5,8 @@
 %ul
   - departments.each do |department|
     %li
-      = link_to(department.name, nodes_path(path: department.home_node.path))
+      = link_to(department.name, public_node_path(department.home_node))
       - if department.agencies.any?
         %ul
           - department.agencies.each do |agency|
-            %li= link_to(agency.name, nodes_path(path: agency.home_node.path))
+            %li= link_to(agency.name, public_node_path(agency.home_node))

--- a/app/views/editorial/nodes/index.html.haml
+++ b/app/views/editorial/nodes/index.html.haml
@@ -17,6 +17,6 @@
     %span
       -if node.state.published?
         =link_to 'View on website',                            |
-          nodes_path(node.path), target: 'GOVAU_PREVIEW'                              |
+          public_node_path(node), target: 'GOVAU_PREVIEW'                              |
       -else
         =link_to 'Preview', previews_path(token: node.token), target: '_blank'

--- a/app/views/editorial/nodes/show.html.haml
+++ b/app/views/editorial/nodes/show.html.haml
@@ -3,7 +3,7 @@
 %h1= node.name
 
 %nav.page-controls
-  %a.badge--default{href: node.full_path}
+  %a.badge--default{href: public_node_path(node)}
     %i.fa.fa-level-up
     View published page
 

--- a/app/views/editorial/requests/show.html.haml
+++ b/app/views/editorial/requests/show.html.haml
@@ -29,4 +29,4 @@
       =f.submit 'Approve membership'
 #{rqst.actioned_status}
 
-=link_to 'Back to topic', nodes_path(@rqst.section.home_node.path)
+=link_to 'Back to topic', public_node_path(@rqst.section.home_node)

--- a/app/views/editorial/sections/show.html.haml
+++ b/app/views/editorial/sections/show.html.haml
@@ -4,7 +4,7 @@
 
 -if @section.home_node
   %nav.page-controls
-    %a.badge--default{href: nodes_path(@section.home_node.path)}
+    %a.badge--default{href: public_node_path(@section.home_node)}
       %i.fa.fa-level-up
       View published section
 

--- a/app/views/layouts/news_article.html.haml
+++ b/app/views/layouts/news_article.html.haml
@@ -2,7 +2,7 @@
   = yield
 
   = content_for :header do
-    %a.site-title{href: nodes_path(@section.home_node.path)}= @section.name
+    %a.site-title{href: public_node_path(@section.home_node)}= @section.name
 
   = content_for :toolbar_actions do
 

--- a/app/views/layouts/section.html.haml
+++ b/app/views/layouts/section.html.haml
@@ -2,7 +2,7 @@
   = yield
 
   = content_for :header do
-    %a.site-title{href: nodes_path(@section.home_node.path)}= @section.name
+    %a.site-title{href: public_node_path(@section.home_node)}= @section.name
 
   = content_for :toolbar_actions do
     = render partial: 'application/page_actions', locals: {section: @section, node: @node}

--- a/app/views/ministers/index.html.haml
+++ b/app/views/ministers/index.html.haml
@@ -9,7 +9,7 @@
 %ul.list-highlighted
   - ministers.each do |minister|
     %li
-      %a{href: nodes_path(path: minister.home_node.path)}
+      %a{href: public_node_path(minister.home_node)}
         -if minister.prefix.present?
           %span
             = minister.prefix

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -7,13 +7,13 @@ Announcements, media releases, interviews, speeches and more from the Australian
     - @articles.each do |article|
       %li
         %article
-          %h2= link_to article.name, article.full_path
+          %h2= link_to article.name, public_node_path(article)
           %div.meta
             %time{ datetime: "#{article.release_date}" } #{l(article.release_date, format: :news)}
-            = link_to article.section.name, article.section.home_node.full_path, { rel: :author }
+            = link_to article.section.name, public_node_path(article.section.home_node), { rel: :author }
           %p
             #{article.short_summary}
           %footer.tags
             %dl
               - article.sections.each do |section|
-                %dd= link_to section.name, section.home_node.full_path
+                %dd= link_to section.name, public_node_path(section.home_node)

--- a/app/views/sections/_menu.html.haml
+++ b/app/views/sections/_menu.html.haml
@@ -2,5 +2,5 @@
   %ul
     - nodes.each do |node|
       %li
-        = link_to(node, nodes_path(node.path))
+        = link_to(node, public_node_path(node))
         = render partial: "menu", locals: {nodes: node.children.published, depth: depth += 1, section: section}

--- a/app/views/templates/news_article.html.haml
+++ b/app/views/templates/news_article.html.haml
@@ -4,7 +4,7 @@
   %dl.list-horizontal
     %div.tags
       - node.sections.each do |distribution|
-        %dd= link_to distribution.name, distribution.home_node.full_path
+        %dd= link_to distribution.name, public_node_path(distribution.home_node)
 
   %h1
     =node.name
@@ -17,7 +17,7 @@
       %li Published date: #{l(node.release_date, format: :news)}
     %li
       Published by:
-      %a= link_to(node.section.name, nodes_path(node.section.home_node.slug))
+      %a= link_to(node.section.name, public_node_path(node.section.home_node))
 
 
   = render partial: 'templates/content_body', object: node.content_body

--- a/app/views/templates/root_node.html.haml
+++ b/app/views/templates/root_node.html.haml
@@ -36,7 +36,7 @@
     - @news.all.each do |news|
       %li
         %article
-          %h3= link_to news.name, news.full_path
+          %h3= link_to news.name, public_node_path(news)
           .meta= news.release_date
 
   %section.bottom-section

--- a/app/views/templates/section_home.html.haml
+++ b/app/views/templates/section_home.html.haml
@@ -13,5 +13,5 @@
     - @news.each do |news|
       %li
         %article
-          %h3= link_to news.name, news.full_path
+          %h3= link_to news.name, public_node_path(news)
           .meta= news.release_date

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -14,7 +14,7 @@ end
 
 crumb :public_node do |node|
   if node.parent.present?
-    link node.name, node.full_path
+    link node.name, public_node_path(node)
     parent :public_node, node.parent
   else
     link 'Home', root_path
@@ -98,6 +98,6 @@ crumb :public_news_articles do |section|
 end
 
 crumb :public_news_article do |node|
-  link node.name, node.full_path
+  link node.name, public_node_path(node)
   parent :public_news_articles, node.section
 end

--- a/spec/controllers/editorial/news_controller_spec.rb
+++ b/spec/controllers/editorial/news_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Editorial::NewsController, type: :controller do
+  include ::NodesHelper
   render_views
 
   let!(:root_node) { Fabricate(:root_node) }
@@ -131,7 +132,7 @@ RSpec.describe Editorial::NewsController, type: :controller do
           }
         }
 
-        it { is_expected.to redirect_to NewsArticle.find(article.id).full_path }
+        it { is_expected.to redirect_to public_node_path(NewsArticle.find(article.id)) }
 
         it 'should update the news article' do
           news = NewsArticle.find(article.id)
@@ -157,7 +158,7 @@ RSpec.describe Editorial::NewsController, type: :controller do
           }
         }
 
-        it { is_expected.to redirect_to article.full_path }
+        it { is_expected.to redirect_to public_node_path(article) }
 
         it 'should reject sections without membership' do
           news = NewsArticle.find(article.id)

--- a/spec/controllers/editorial/submissions_controller_spec.rb
+++ b/spec/controllers/editorial/submissions_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Editorial::SubmissionsController, type: :controller do
+  include ::NodesHelper
   render_views
 
   describe 'GET #show' do
@@ -167,7 +168,7 @@ RSpec.describe Editorial::SubmissionsController, type: :controller do
 
       context '(:accept)' do
         subject { post :update, section_id: submission.section, id: submission.id, accept: true }
-        it { is_expected.to redirect_to submission.revisable.full_path }
+        it { is_expected.to redirect_to public_node_path(submission.revisable) }
         it 'change to accepted' do
           expect { subject }.to change { submission.reload.accepted? }.from(false).to(true)
         end

--- a/spec/features/controls_spec.rb
+++ b/spec/features/controls_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "controls", :type => :feature do
+  include ::NodesHelper
   Warden.test_mode!
 
   let!(:root_node) { Fabricate(:root_node) }
@@ -9,7 +10,7 @@ RSpec.describe "controls", :type => :feature do
 
   context 'not signed in' do
     before do
-      visit nodes_path(node.path)
+      visit public_node_path(node)
     end
     it 'should not show controls' do
       expect(page).to have_no_css('.controls--contrast')
@@ -68,7 +69,7 @@ RSpec.describe "controls", :type => :feature do
 
       context 'when visiting section' do
         before do
-          visit nodes_path(section.home_node.path)
+          visit public_node_path(section.home_node)
         end
 
         include_examples 'no New page link'
@@ -93,7 +94,7 @@ RSpec.describe "controls", :type => :feature do
         let(:agency_home) { Fabricate(:node, parent: root_node, section: agency) }
 
         before do
-          visit nodes_path(agency_home.path)
+          visit public_node_path(agency_home)
         end
 
         it 'does not show request membership link' do
@@ -136,7 +137,7 @@ RSpec.describe "controls", :type => :feature do
         let(:section) { Fabricate(:section, cms_type: "govcms") }
 
         before do
-          visit nodes_path(path: section.home_node.path)
+          visit public_node_path(section.home_node)
         end
         include_examples 'no New page link'
         include_examples 'no New news article link'

--- a/spec/features/creating_content_spec.rb
+++ b/spec/features/creating_content_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'creating content:', type: :feature do
+  include ::NodesHelper
   Warden.test_mode!
 
   before :each do
@@ -153,7 +154,7 @@ RSpec.describe 'creating content:', type: :feature do
     let(:node) { Fabricate(:node, section: section) }
 
     it 'should allow a user to create a child of a specific type' do
-      visit nodes_path path: node.path
+      visit public_node_path(node)
       click_link 'New page'
       expect(page).to have_content 'Create a new page'
       select 'General content', from: 'Page type'
@@ -162,7 +163,7 @@ RSpec.describe 'creating content:', type: :feature do
     end
 
     it 'should prefill the section and parent' do
-      visit nodes_path path: node.path
+      visit public_node_path(node)
       click_link 'New page'
       expect(page).to have_content 'Create a new page'
       click_button 'New page'

--- a/spec/features/editing_content_spec.rb
+++ b/spec/features/editing_content_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'editing content', type: :feature do
+  include ::NodesHelper
 
   Warden.test_mode!
   let!(:root_node) { Fabricate(:root_node) }
@@ -65,7 +66,7 @@ RSpec.describe 'editing content', type: :feature do
 
     it 'should prefill the form' do
       [node1, node2].each do |node|
-        visit node.full_path
+        visit public_node_path(node)
         click_link 'Edit'
         expect(find_field('Body').value).to eq node.content_body
         expect(find_field('Name').value).to eq node.name
@@ -76,7 +77,7 @@ RSpec.describe 'editing content', type: :feature do
 
     context 'for a news article' do
       it 'should prefill the form' do
-        visit node2.full_path
+        visit public_node_path(node2)
         click_link 'Edit metadata'
         field = 'node_release_date'
         expect(find_field("#{field}_1i").value).to eq node2.release_date.year.to_s

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Node, type: :model do
+  include ::NodesHelper
+
   it { is_expected.to belong_to :section }
   it { is_expected.to belong_to :parent }
   it { is_expected.to have_many :children }
@@ -172,7 +174,7 @@ RSpec.describe Node, type: :model do
 
     context 'for a news article' do
       it 'matches its url helper' do
-        expect(article.full_path).to eq(Rails.application.routes.url_helpers.news_article_path(
+        expect(public_node_path(article)).to eq(Rails.application.routes.url_helpers.news_article_path(
           article.section.home_node.slug, article.slug
         ))
       end
@@ -180,7 +182,7 @@ RSpec.describe Node, type: :model do
 
     context 'for a general node' do
       it 'matches its url helper' do
-        expect(node.full_path).to eq(Rails.application.routes.url_helpers.nodes_path(node.path))
+        expect(public_node_path(node)).to eq(Rails.application.routes.url_helpers.nodes_path(node.path))
       end
     end
   end


### PR DESCRIPTION
- removed `Node#full_path`
- subclasses override `Node#path_elements` if they need custom routing
- all nodes paths generated using a helper that hides *how* path is generated

  e.g. `public_node_path(news_article)`

`public_node_path` is the publically-routeable path for the node. It's
currently defined as `nodes_path(path: node.path)`.