### PR TITLE
fix rendering of abstract on base node template

### DIFF
--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -1,7 +1,7 @@
 <head>
   <title><%= title %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <%= yield :meta_description %>
+  <meta name="description" content="<%= yield :meta_description %>">
   <script>
     (function (h) {
     h.className = h.className.replace('no-js', 'js')

--- a/app/views/templates/node.html.haml
+++ b/app/views/templates/node.html.haml
@@ -4,6 +4,11 @@
   %h1
     =node.name
 
+  %div.abstract
+    =node.short_summary
+    - if node.summary
+      != markdown_content node.summary
+
   = render partial: 'templates/content_body', object: node.content_body
 
   %p

--- a/app/views/templates/node.html.haml
+++ b/app/views/templates/node.html.haml
@@ -4,11 +4,6 @@
   %h1
     =node.name
 
-  %div.abstract
-    =node.short_summary
-    - if node.summary
-      != markdown_content node.summary
-
   = render partial: 'templates/content_body', object: node.content_body
 
   %p


### PR DESCRIPTION
Fix the metatag wrapping for the description based on short_summary of a node.