### PR TITLE
[SITES-419][SITES-427] delegate section name and slug to its home node

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -39,7 +39,7 @@ class NewsArticle < Node
   # wrapper around the url helpers, to allow this model to override the default
   # redirect action.
   def path_elements
-    [section.home_node.slug, 'news', slug]
+    [section.slug, 'news', slug]
   end
 
   # http://norman.github.io/friendly_id/file.Guide.html#Column_or_Method_

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -13,8 +13,6 @@ class Section < ApplicationRecord
         foreign_key: :section_id,
         association_foreign_key: :connection_id
 
-  validates :name, uniqueness: { case_sensitive: false }
-
   # Note: resourcify must be called in every subclass so rolify will work
   resourcify
 
@@ -31,6 +29,17 @@ class Section < ApplicationRecord
 
   def home_node
     nodes.with_sectionless_parent.first
+  end
+
+  # we can't use delegate :name, to home_node because we have to create the Section before the SectionHome
+  # we can't have the SectionHome delegate :name to the section because that doesn't work with the revisable system
+  # So manually override name to delegate to the home_node if it exists
+  def name
+    if home_node
+      home_node.name
+    else
+      super
+    end
   end
 
   private

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -13,6 +13,8 @@ class Section < ApplicationRecord
         foreign_key: :section_id,
         association_foreign_key: :connection_id
 
+  delegate :slug, to: :home_node, allow_nil: true
+
   # Note: resourcify must be called in every subclass so rolify will work
   resourcify
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -95,7 +95,7 @@ crumb :new_editorial_request do |section|
 end
 
 crumb :public_news_articles do |section|
-  link 'News', section_news_articles_path(section.home_node.slug)
+  link 'News', section_news_articles_path(section.slug)
   parent :public_node, section.home_node
 end
 

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe NewsController, type: :controller do
 
     context 'when a user is not authorised' do
       context 'for a published page' do
-        before { get :show, section: section_a.home_node.slug, slug: article_published.slug }
+        before { get :show, section: section_a.slug, slug: article_published.slug }
 
         it { expect(response).to be_success }
         it { expect(assigns(:node)).to eq(article_published) }
@@ -22,7 +22,7 @@ RSpec.describe NewsController, type: :controller do
       context 'for a draft page' do
         it 'should throw a not found' do
           expect {
-             get :show, section: section_a.home_node.slug, slug: article_draft.slug
+             get :show, section: section_a.slug, slug: article_draft.slug
           }.to raise_error ActiveRecord::RecordNotFound
         end
       end

--- a/spec/features/editing_content_spec.rb
+++ b/spec/features/editing_content_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'editing content', type: :feature do
     let!(:node) { Fabricate(:node, section: section, parent: root_node) }
 
     it 'should show a link to edit the content in the CMS' do
-      visit "/#{node.slug}"
+      visit public_node_path(node)
       expect(page).to have_link('Edit')
     end
 
@@ -38,14 +38,14 @@ RSpec.describe 'editing content', type: :feature do
       let!(:submission) { Fabricate(:submission, revision: revision, submitter: author)}
 
       it 'should show a link to view the existing submission' do
-        visit "/#{node.slug}"
+        visit public_node_path(node)
         expect(page).to have_link('View submission')
       end
 
       it 'should show an edit link for a user without an open submission' do
         logout(author)
         login_as(user_b)
-        visit "/#{node.section.slug}/#{node.slug}"
+        visit public_node_path(node)
         expect(page).to have_link('Edit')
       end
     end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Node, type: :model do
     context 'for a news article' do
       it 'matches its url helper' do
         expect(public_node_path(article)).to eq(Rails.application.routes.url_helpers.news_article_path(
-          article.section.home_node.slug, article.slug
+          article.section.slug, article.slug
         ))
       end
     end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Section, type: :model do
   let!(:root_node) { Fabricate(:root_node) }
 
   it { is_expected.to have_many :nodes }
-  it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
 
   describe '#users' do
     context 'section with no users' do
@@ -38,6 +37,14 @@ RSpec.describe Section, type: :model do
 
     it 'should be a child of the root node' do
       expect(subject.parent).to eq Node.root_node
+    end
+  end
+
+  describe '#name' do
+    let(:section) { Fabricate(:section, name: 'original') }
+    it do
+      expect{ section.home_node.update(name: 'updated') }.to(
+        change{section.reload.name}.from('original').to('updated'))
     end
   end
 end


### PR DESCRIPTION
There's a bunch of bootstrapping issues with trying to delegate the name between the section and its home node. So this does it halfway. It's not great but it works.