### PR TITLE
Submissions usability fixes

### DIFF
--- a/app/controllers/editorial/submissions_controller.rb
+++ b/app/controllers/editorial/submissions_controller.rb
@@ -10,7 +10,7 @@ module Editorial
 
 
     def index
-      @submissions = scope.open.for(current_user)
+      @submissions = scope.open
     end
 
     def create

--- a/app/controllers/editorial/submissions_controller.rb
+++ b/app/controllers/editorial/submissions_controller.rb
@@ -10,7 +10,12 @@ module Editorial
 
 
     def index
-      @submissions = scope.open
+      @submissions = scope.open.recent
+
+      # Filter submissions to current user's unless s/he is a reviewer
+      unless can? :review_in, @section
+        @submissions = @submissions.for(current_user)
+      end
     end
 
     def create

--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -2,7 +2,7 @@ class RequestDecorator < Draper::Decorator
   decorates_association :approver, with: UserDecorator
   delegate_all
   delegate :name, to: :section, prefix: true
-  delegate :full_name, to: :approver, allow_nil: true, prefix: true
+  delegate :display_name, to: :approver, allow_nil: true, prefix: true
 
   def open?
     object.state == 'requested'
@@ -14,7 +14,7 @@ class RequestDecorator < Draper::Decorator
 
   def actioned_status
     if closed?
-      "This request was #{object.state} at #{actioned_at} by #{approver_full_name}"
+      "This request was #{object.state} at #{actioned_at} by #{approver_display_name}"
     else
       "Pending"
     end

--- a/app/decorators/submission_decorator.rb
+++ b/app/decorators/submission_decorator.rb
@@ -3,8 +3,8 @@ class SubmissionDecorator < Draper::Decorator
   decorates_association :submitter
   decorates_association :reviewer
   decorates_association :revisable
-  delegate :full_name, to: :submitter, prefix: true, allow_nil: true
-  delegate :full_name, to: :reviewer, prefix: true, allow_nil: true
+  delegate :display_name, to: :submitter, prefix: true, allow_nil: true
+  delegate :display_name, to: :reviewer, prefix: true, allow_nil: true
 
   def submitted_content
     RevisionContent.new(revision)

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,8 +1,12 @@
 class UserDecorator < Draper::Decorator
   delegate_all
 
-  def full_name
-    "#{object.first_name} #{object.last_name}"
+  def display_name
+    if object.first_name.present? || object.last_name.present?
+      "#{object.first_name} #{object.last_name}"
+    else
+      object.email
+    end
   end
 
   def pending_request_for(section)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,9 +6,11 @@ class Ability
 
     if user.has_role? :admin
       can :manage, :all
+
       cannot :manage, Node do |node|
         node.section.cms_type != Section::COLLABORATE_CMS
       end
+
       cannot :create_in, Section do |section|
         section.cms_type != Section::COLLABORATE_CMS
       end
@@ -17,6 +19,7 @@ class Ability
     if user.id
       # TODO: Should all logged in users be able to view editorial pages?
       can :view, :editorial_page
+
       can :manage, Node do |node|
         user.has_role?(:author, node.section) &&
             node.section.cms_type == Section::COLLABORATE_CMS
@@ -31,10 +34,12 @@ class Ability
       can :read, Node do |node|
         user.has_role?(:reviewer, node.section)
       end
+
       can :create_in, Section do |section|
         user.has_role?(:author, section) &&
             section.cms_type == Section::COLLABORATE_CMS
       end
+
       can :read, Section do |section|
         (
           user.has_role?(:author, section)   ||
@@ -42,13 +47,16 @@ class Ability
           user.has_role?(:owner, section)
         ) && section.cms_type == Section::COLLABORATE_CMS
       end
+
       can :review, Submission do |submission|
         submission.submitted? && submission.section.present? &&
           user.has_role?(:reviewer, submission.section)
       end
+
+      can :review_in, Section do |section|
+        user.has_role? :reviewer, section
+      end
     end
-
-
 
     # Everyone (signed in or not) can view published pages.
     can :read, Node, :state => :published

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -30,13 +30,11 @@ class Submission < ApplicationRecord
     where(submitter: user).without_state(:accepted, :rejected).order(updated_at: :desc)
   }
 
-  scope :open, -> {
-    without_state(:accepted, :rejected)
-  }
+  scope :open, -> { without_state(:accepted, :rejected) }
 
-  scope :for, -> (user) {
-    where(submitter: user).order(updated_at: :desc)
-  }
+  scope :for, -> (user) { where(submitter: user) }
+
+  scope :recent, -> { order(updated_at: :desc) }
 
   validates_presence_of :revision
   validates_presence_of :submitter

--- a/app/views/application/_signed_in_nav.html.haml
+++ b/app/views/application/_signed_in_nav.html.haml
@@ -13,7 +13,7 @@
       %ul.inline-links--inverted
         %li
           %i.fa-user.fa
-          = #{current_user.full_name}
+          = #{current_user.display_name}
         %li= link_to('Sign out', destroy_user_session_path, method: :delete)
 
 

--- a/app/views/editorial/nodes/show.html.haml
+++ b/app/views/editorial/nodes/show.html.haml
@@ -72,7 +72,7 @@
     - node.submissions.sort_by{|s| s.updated_at}.reverse.each do |submission|
       %tr
         %td= link_to('View', editorial_section_submission_path(@section, submission))
-        %td= submission.submitter_full_name
-        %td= submission.reviewer_full_name
+        %td= submission.submitter_display_name
+        %td= submission.reviewer_display_name
         %td= t("submission.state.#{submission.state}")
         %td= l(submission.updated_at)

--- a/app/views/editorial/requests/new.html.haml
+++ b/app/views/editorial/requests/new.html.haml
@@ -11,7 +11,7 @@
 
   %ul
     - owners.each do |owner|
-      %li #{owner.full_name} (#{owner.email})
+      %li #{owner.display_name} (#{owner.email})
 
 
 .fieldset

--- a/app/views/editorial/requests/show.html.haml
+++ b/app/views/editorial/requests/show.html.haml
@@ -1,6 +1,6 @@
 - breadcrumb :editorial_request, @rqst
 
-%h1 #{requestor.full_name} wants to join #{rqst.section_name}
+%h1 #{requestor.display_name} wants to join #{rqst.section_name}
 
 - if current_user.in?(@owners)
   %p
@@ -20,7 +20,7 @@
 %h2 Owners
 %ul
   - owners.each do |owner|
-    %li #{owner.full_name}
+    %li #{owner.display_name}
 
 -if current_user.in?(@owners)
   - if rqst.open?

--- a/app/views/editorial/sections/collaborators.html.haml
+++ b/app/views/editorial/sections/collaborators.html.haml
@@ -8,7 +8,7 @@
   %ul
     - @pending.each do |p|
       %li
-        =link_to "#{p.user.decorate.full_name} (#{p.user.email})", editorial_section_request_path(@section, p)
+        =link_to "#{p.user.decorate.display_name} (#{p.user.email})", editorial_section_request_path(@section, p)
 
 %table.content-table
   %thead
@@ -19,7 +19,7 @@
   %tbody
     - users.each do |user|
       %tr
-        %td #{user.full_name}
+        %td #{user.display_name}
         %td #{user.email}
         %td
           = user.roles_for(@section).join ', '

--- a/app/views/editorial/submissions/_submissions.haml
+++ b/app/views/editorial/submissions/_submissions.haml
@@ -9,4 +9,4 @@
       %tr
         %td= link_to submission.revisable.name, editorial_section_submission_path(submission.section, submission)
         %td #{submission.submitted_at}
-        %td= submission.submitter_full_name
+        %td= submission.submitter_display_name

--- a/app/views/editorial/submissions/show.haml
+++ b/app/views/editorial/submissions/show.haml
@@ -19,13 +19,13 @@
       %td= t("submission.state.#{submission.state}")
     %tr
       %td Submitted by
-      %td= submission.submitter_full_name
+      %td= submission.submitter_display_name
     %tr
       %td Submitted at
       %td= l(submission.submitted_at) unless submission.submitted_at.blank?
     %tr
       %td Reviewed by
-      %td= submission.reviewer_full_name
+      %td= submission.reviewer_display_name
     %tr
       %td Reviewed at
       %td= l(submission.reviewed_at) unless submission.reviewed_at.blank?

--- a/spec/controllers/editorial/submissions_controller_spec.rb
+++ b/spec/controllers/editorial/submissions_controller_spec.rb
@@ -50,32 +50,8 @@ RSpec.describe Editorial::SubmissionsController, type: :controller do
         get :index, section_id: section
       end
 
-      it 'should return only their submission for section' do
-        expect(assigns('submissions')).to eq([submission_b])
-      end
-    end
-
-    context 'as user_a on section' do
-
-      before do
-        sign_in(user_a)
-        get :index, section_id: section
-      end
-
-      it 'should return only their submission for section' do
-        expect(assigns('submissions')).to eq([submission_a])
-      end
-    end
-
-    context 'as user_a on a different section' do
-
-      before do
-        sign_in(user_a)
-        get :index, section_id: section_b
-      end
-
-      it 'should return only their submission for that section' do
-        expect(assigns('submissions')).to eq([submission_c])
+      it 'should show all submissions for section' do
+        expect(assigns('submissions')).to include submission_a, submission_b
       end
     end
 

--- a/spec/fabricators/user.rb
+++ b/spec/fabricators/user.rb
@@ -9,13 +9,16 @@ Fabricator(:user) do
     end
     [:author_of, :reviewer_of, :owner_of].each do |role|
       if transients[role]
-        user.add_role(role[0..-4], transients[role])
+        Array.wrap(transients[role]).each do |section|
+          user.add_role(role[0..-4], section)
+        end
       end
     end
 
     if transients[:owner_of]
-      user.add_role(:owner, transients[:owner_of])
+      Array.wrap(transients[:owner_of]).each do |section|
+        user.add_role(:owner, section)
+      end
     end
   end
 end
-


### PR DESCRIPTION
SITES-253 Show all submissions on submissions index
SITES-462 Show email if name is missing for user

Some quick fixes to make submissions more useful now that content editors want to allow only certain users to review submissions rather than everyone self-approving. 

The collection shown by editorial/submissions/index wasn't very useful (only showed user's own submissions) - this PR changes it to show all submissions in the section. 

Also, `UserDecorator#full_name` wasn't very useful for the users on our system as none of them have names. (There's no name fields in the signup form, nor in the admin UI). To allow content reviewers to see who has authored submissions, I've changed this to `display_name` and (for the time being) it shows the email if there's no name available. 