### PR TITLE
[SITES-403 | SITES-467] Feature/section news index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ This file is influenced by http://keepachangelog.com/.
 - Added admin-only option to stop a node appearing in breadcrumbs and the menu
 - Added links on department homepages to related ministers
 - Added long summary field for section_home form and template
+- Added route for /:section/news to offer section-filtered view of news items
 
 ### Changed
 
 - Short/long summary fields for all nodes sit within page abstract
 - Display dates in Sydney timezone
 - Relabeled 'Summary' field to 'Long summary'
+- Shifted news item breadcrumbs to sit beneath Home > News
 
 ### Fixed
 

--- a/app/controllers/editorial/news_controller.rb
+++ b/app/controllers/editorial/news_controller.rb
@@ -33,7 +33,7 @@ module Editorial
         if current_user.is_member?(Section.find(@form.section_id))
           # TODO: move this into a form validator
           # Prevents distribution list being created for publisher
-          @form.section_ids.reject! do |s_id|
+          @form.section_ids.reject!(&:blank?).reject! do |s_id|
             s_id == @form.section_id ||
                 !current_user.is_member?(Section.find(s))
           end
@@ -68,7 +68,7 @@ module Editorial
 
       if @form.validate(params.require(:node))
         if current_user.is_member?(Section.find(@form.section_id))
-          @form.section_ids.reject! do |s|
+          @form.section_ids.reject!(&:blank?).reject! do |s|
             s == @form.section_id.to_s ||
                 !current_user.is_member?(Section.find(s))
           end

--- a/app/controllers/editorial/news_controller.rb
+++ b/app/controllers/editorial/news_controller.rb
@@ -33,8 +33,8 @@ module Editorial
         if current_user.is_member?(Section.find(@form.section_id))
           # TODO: move this into a form validator
           # Prevents distribution list being created for publisher
-          @form.section_ids = @form.section_ids.reject(&:blank?).reject! do |s_id|
-            s_id == @form.section_id ||
+          @form.section_ids.reject! do |s_id|
+            s.blank? || s_id == @form.section_id ||
                 !current_user.is_member?(Section.find(s))
           end
 
@@ -68,9 +68,10 @@ module Editorial
 
       if @form.validate(params.require(:node))
         if current_user.is_member?(Section.find(@form.section_id))
-          @form.section_ids = @form.section_ids.reject(&:blank?).reject! do |s|
-            s == @form.section_id.to_s ||
-                !current_user.is_member?(Section.find(s))
+          @form.section_ids.reject! do |s|
+            s.blank? ||
+              s == @form.section_id.to_s ||
+              !current_user.is_member?(Section.find(s))
           end
 
           @form.save do |params|

--- a/app/controllers/editorial/news_controller.rb
+++ b/app/controllers/editorial/news_controller.rb
@@ -33,7 +33,7 @@ module Editorial
         if current_user.is_member?(Section.find(@form.section_id))
           # TODO: move this into a form validator
           # Prevents distribution list being created for publisher
-          @form.section_ids.reject!(&:blank?).reject! do |s_id|
+          @form.section_ids = @form.section_ids.reject(&:blank?).reject! do |s_id|
             s_id == @form.section_id ||
                 !current_user.is_member?(Section.find(s))
           end
@@ -68,7 +68,7 @@ module Editorial
 
       if @form.validate(params.require(:node))
         if current_user.is_member?(Section.find(@form.section_id))
-          @form.section_ids.reject!(&:blank?).reject! do |s|
+          @form.section_ids = @form.section_ids.reject(&:blank?).reject! do |s|
             s == @form.section_id.to_s ||
                 !current_user.is_member?(Section.find(s))
           end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -6,6 +6,11 @@ class NewsController < ApplicationController
 
   def index
     @articles = NewsArticle.published.by_release_date.by_published_at
+
+    if params[:section].present?
+      set_section
+      @articles = @articles.by_section(@section)
+    end
   end
 
 

--- a/app/forms/news_article_form.rb
+++ b/app/forms/news_article_form.rb
@@ -3,5 +3,4 @@ class NewsArticleForm < NodeForm
   property :section_ids
   property :release_date, multi_params: true
   validates :release_date, presence: true
-  validates :summary, presence: true
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -45,7 +45,9 @@ class Section < ApplicationRecord
   end
 
   def news_node
-    nodes.with_name('News')
+    # There can only be one ...
+    # TODO: select this by NewsAggegator type, once it exists
+    nodes.with_name('News').first
   end
 
   private

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -68,7 +68,7 @@ class Section < ApplicationRecord
     end
   end
 
-
+  # TODO: add a after_create hook for this method
   def generate_news_node
     unless news_node.present?
       # TODO: Create NewsNode

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -69,7 +69,8 @@ class Section < ApplicationRecord
   end
 
   # TODO: add a after_create hook for this method
-  def generate_news_node
+  # TODO: refactor generate_home_node into this
+  def generate_indispensable_nodes
     unless news_node.present?
       # TODO: Create NewsNode
     end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -44,6 +44,10 @@ class Section < ApplicationRecord
     end
   end
 
+  def news_node
+    nodes.with_name('News')
+  end
+
   private
 
   def set_default_cms_type
@@ -59,6 +63,13 @@ class Section < ApplicationRecord
         node.state = 'published'
         node.parent = Node.root_node
       end
+    end
+  end
+
+
+  def generate_news_node
+    unless news_node.present?
+      # TODO: Create NewsNode
     end
   end
 end

--- a/app/views/editorial/news/new.html.haml
+++ b/app/views/editorial/news/new.html.haml
@@ -5,7 +5,7 @@
     = f.input :section_id, collection: @sections, label: 'Publisher'
     = f.input :name, label: 'Title'
     = f.input :short_summary
-    = f.input :summary, as: :text, input_html: {rows: 5}, label: 'Long summary'
+    = f.input :summary, as: :text, input_html: {rows: 5}, label: 'Long summary', required: false
     = f.input :content_body, as: :text, label: 'Body', input_html: {rows: 15}
     = f.input :release_date, as: :date
     Distributions

--- a/app/views/editorial/submissions/_news_article.html.haml
+++ b/app/views/editorial/submissions/_news_article.html.haml
@@ -1,1 +1,1 @@
-~ f.input :summary, as: :text, input_html: {rows: 5}, label: 'Long summary'
+~ f.input :summary, as: :text, input_html: {rows: 5}, label: 'Long summary', required: false

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -1,5 +1,5 @@
 - if @section
-  - breadcrumb :public_news_articles, @section
+  - breadcrumb :section_news_articles, @section
 - else
   - breadcrumb :public_news_aggregator
 

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -1,3 +1,8 @@
+- if @section
+  - breadcrumb :public_news_articles, @section
+- else
+  - breadcrumb :public_news_aggregator
+
 %h1 News
 
 Announcements, media releases, interviews, speeches and more from the Australian Government.

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -1,7 +1,7 @@
 - if @section
   - breadcrumb :section_news_articles, @section
 - else
-  - breadcrumb :public_news_aggregator
+  - breadcrumb :public_news_articles
 
 %h1 News
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -105,11 +105,7 @@ crumb :public_news_article do |node|
 end
 
 crumb :section_news_articles do |section|
-  link 'News', nil
+  link 'News', section_news_articles_path(section)
   parent :public_node, section.home_node
 end
 
-crumb :public_news_aggregator do
-  link 'News', nil
-  parent :public_node, Node.root_node
-end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -12,6 +12,10 @@ crumb :ministers do
   parent :public_node, Node.root_node
 end
 
+crumb :public_root do
+  link 'Home', root_path
+end
+
 crumb :public_node do |node|
   if node.parent.present?
     unless node.options.suppress_in_nav
@@ -102,4 +106,9 @@ end
 crumb :public_news_article do |node|
   link node.name, public_node_path(node)
   parent :public_news_articles, node.section
+end
+
+crumb :public_news_aggregator do
+  link 'News', nil
+  parent :public_root
 end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -12,10 +12,6 @@ crumb :ministers do
   parent :public_node, Node.root_node
 end
 
-crumb :public_root do
-  link 'Home', root_path
-end
-
 crumb :public_node do |node|
   if node.parent.present?
     unless node.options.suppress_in_nav
@@ -100,7 +96,7 @@ end
 
 crumb :public_news_articles do
   link 'News', news_articles_path
-  parent :public_root
+  parent :public_node, Node.root_node
 end
 
 crumb :public_news_article do |node|
@@ -115,5 +111,5 @@ end
 
 crumb :public_news_aggregator do
   link 'News', nil
-  parent :public_root
+  parent :public_node, Node.root_node
 end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -98,14 +98,19 @@ crumb :new_editorial_request do |section|
   parent :editorial_root
 end
 
-crumb :public_news_articles do |section|
-  link 'News', section_news_articles_path(section.slug)
-  parent :public_node, section.home_node
+crumb :public_news_articles do
+  link 'News', news_articles_path
+  parent :public_root
 end
 
 crumb :public_news_article do |node|
   link node.name, public_node_path(node)
-  parent :public_news_articles, node.section
+  parent :public_news_articles
+end
+
+crumb :section_news_articles do |section|
+  link 'News', nil
+  parent :public_node, section.home_node
 end
 
 crumb :public_news_aggregator do


### PR DESCRIPTION
This PR moves us closer to phasing out news controller & routes.

The details of next steps are described in SITES-466.

This PR will use the `/news` and `/:section/news` routes to display news listings, with the latter filtering by section. For this to be displayed on a page's navbar, an author must create a general content node with the slug of 'news' - in most instances _this has already been done_, which is why this solution assumes this.

Moving forward, these GeneralContent nodes will be phased out for a specific NewsAggegator type. In the interim, the already-existing nodes provide a nice way of exposing the route for a given section, which `routes.rb` takes over.

This PR also includes some foundational plumbing in `section.rb` to manage the create action of a news aggregator on section creation.