### PR TITLE
SITES-438 show all submitted fields in submission

### DIFF
--- a/app/models/revision_content.rb
+++ b/app/models/revision_content.rb
@@ -19,6 +19,18 @@ class RevisionContent
     end
   end
 
+  def main_keys_in_order
+    [:name, :short_summary, :summary, :content_body]
+  end
+
+  def optional_keys_in_order
+    node.all_content.keys.reject do |key|
+      get_content(key).nil?
+    end.reject do |key|
+      main_keys_in_order.include?(key)
+    end.sort
+  end
+
   def get_content(content_key)
     return nil unless traversal_sequence.any? { |rev| rev.diffs[content_key].present? }
 
@@ -44,6 +56,10 @@ class RevisionContent
     else
       super
     end
+  end
+
+  def [](key)
+    get_content(key)
   end
 
   private

--- a/app/views/editorial/submissions/_content.haml
+++ b/app/views/editorial/submissions/_content.haml
@@ -6,14 +6,38 @@
   %dl
     %dt Name
     %dd
-      - if content.name.nil?
+      - if content[:name].nil?
         = defaults[:name]
       - else
-        = content.name
-    %dt Body
+        = content[:name]
+
+    %dt Short summary
     %dd
-      - if content.content_body.nil?
+      - if content[:short_summary].nil?
+        none
+      - else
+        = content[:short_summary]
+
+    %dt Summary
+    %dd
+      - if content[:summary].nil?
         none
       - else
         %div.content-block
-          != markdown_content content.content_body
+          != markdown_content content[:summary]
+
+    %dt Body
+    %dd
+      - if content[:content_body].nil?
+        none
+      - else
+        %div.content-block
+          != markdown_content content[:content_body]
+
+    - content.optional_keys_in_order.each do |key|
+      %dt= key.to_s.titleize
+      %dd
+        - if content[key].nil?
+          none
+        - else
+          = content[key]


### PR DESCRIPTION
Name & Body are shown first and then all remaining fields are iterated over in lexicographical order.

If we want to control the order of the fields then we'll need to create a union of all the fields of all node types and manually specify the order in the template. And we'd need to remember to update the template whenever a new field is added.