### PR TITLE
Listing page links styling fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This file is influenced by http://keepachangelog.com/.
 
 ### Fixed
 
+ - Listing pages of departments/news/ministers etc. now show links correctly styled
+
 
 ## [v0.7.1] - 2016-07-28
 ### Added

--- a/app/assets/stylesheets/_content-listing.scss
+++ b/app/assets/stylesheets/_content-listing.scss
@@ -1,0 +1,6 @@
+.content-listing {
+  @include outer-container;
+  @include span-columns(12 of 12);
+  @include link-colours($non-black, $light-aqua, $non-black);
+  @include button-colours($button-bg-colour, $button-bg-colour--hover, $button-bg-colour--active, $button-text-colour);
+}

--- a/app/assets/stylesheets/_homepage.scss
+++ b/app/assets/stylesheets/_homepage.scss
@@ -1,7 +1,3 @@
-.home {
-  width:100% !important;
-}
-
 .home-category-list li {
   border-left: 1px solid $border-colour;
   border-top: 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@
  @import "page_controls";
  @import "tab";
  @import "homepage";
+ @import "content-listing";
 
  //all of the below sass will need to be removed once it is added to UI Kit
  @import "callout-basic"; // not yet added

--- a/app/views/departments/index.html.haml
+++ b/app/views/departments/index.html.haml
@@ -1,12 +1,12 @@
 - breadcrumb :departments
-
-%h1
-  Departments
-%ul
-  - departments.each do |department|
-    %li
-      = link_to(department.name, public_node_path(department.home_node))
-      - if department.agencies.any?
-        %ul
-          - department.agencies.each do |agency|
-            %li= link_to(agency.name, public_node_path(agency.home_node))
+%article.content-listing
+  %h1
+    Departments
+  %ul
+    - departments.each do |department|
+      %li
+        = link_to(department.name, public_node_path(department.home_node))
+        - if department.agencies.any?
+          %ul
+            - department.agencies.each do |agency|
+              %li= link_to(agency.name, public_node_path(agency.home_node))

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,9 +1,10 @@
-%h2 Resend confirmation instructions
-= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-  = f.error_notification
-  = f.full_error :confirmation_token
-  .form-inputs
-    = f.input :email, required: true, autofocus: true
-  .form-actions
-    = f.button :submit, "Resend confirmation instructions"
-= render "devise/shared/links"
+%article.content-listing
+  %h2 Resend confirmation instructions
+  = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+    = f.error_notification
+    = f.full_error :confirmation_token
+    .form-inputs
+      = f.input :email, required: true, autofocus: true
+    .form-actions
+      = f.button :submit, "Resend confirmation instructions"
+  = render "devise/shared/links"

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,11 +1,12 @@
-%h2 Change your password
-= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-  = f.error_notification
-  = f.input :reset_password_token, as: :hidden
-  = f.full_error :reset_password_token
-  .form-inputs
-    = f.input :password, label: "New password", required: true, autofocus: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
-    = f.input :password_confirmation, label: "Confirm your new password", required: true
-  .form-actions
-    = f.button :submit, "Change my password"
-= render "devise/shared/links"
+%article.content-listing
+  %h2 Change your password
+  = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+    = f.error_notification
+    = f.input :reset_password_token, as: :hidden
+    = f.full_error :reset_password_token
+    .form-inputs
+      = f.input :password, label: "New password", required: true, autofocus: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
+      = f.input :password_confirmation, label: "Confirm your new password", required: true
+    .form-actions
+      = f.button :submit, "Change my password"
+  = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,8 +1,9 @@
-%h2 Forgot your password?
-= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = f.error_notification
-  .form-inputs
-    = f.input :email, required: true, autofocus: true
-  .form-actions
-    = f.button :submit, "Send me reset password instructions"
-= render "devise/shared/links"
+%article.content-listing
+  %h2 Forgot your password?
+  = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+    = f.error_notification
+    .form-inputs
+      = f.input :email, required: true, autofocus: true
+    .form-actions
+      = f.button :submit, "Send me reset password instructions"
+  = render "devise/shared/links"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,18 +1,19 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = f.error_notification
-  .form-inputs
-    = f.input :email, required: true, autofocus: true
-    - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-      %p
-        Currently waiting confirmation for: #{resource.unconfirmed_email}
-    = f.input :password, autocomplete: "off", hint: "leave it blank if you don't want to change it", required: false
-    = f.input :password_confirmation, required: false
-    = f.input :current_password, hint: "we need your current password to confirm your changes", required: true
-  .form-actions
-    = f.button :submit, "Update", role: 'button'
-%h3 Cancel my account
-%p
-  Unhappy? #{link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+%article.content-listing
+  %h2
+    Edit #{resource_name.to_s.humanize}
+  = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+    = f.error_notification
+    .form-inputs
+      = f.input :email, required: true, autofocus: true
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        %p
+          Currently waiting confirmation for: #{resource.unconfirmed_email}
+      = f.input :password, autocomplete: "off", hint: "leave it blank if you don't want to change it", required: false
+      = f.input :password_confirmation, required: false
+      = f.input :current_password, hint: "we need your current password to confirm your changes", required: true
+    .form-actions
+      = f.button :submit, "Update", role: 'button'
+  %h3 Cancel my account
+  %p
+    Unhappy? #{link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+  = link_to "Back", :back

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,12 +1,13 @@
-%h2 Sign up
-= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = f.error_notification
-  .form-inputs
-    = f.input :email, required: true, autofocus: true
-    = f.input :first_name, required: false
-    = f.input :last_name, required: false
-    = f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
-    = f.input :password_confirmation, required: true
-  .form-actions
-    = f.button :submit, "Sign up", role: 'button'
-= render "devise/shared/links"
+%article.content-listing
+  %h2 Sign up
+  = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+    = f.error_notification
+    .form-inputs
+      = f.input :email, required: true, autofocus: true
+      = f.input :first_name, required: false
+      = f.input :last_name, required: false
+      = f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
+      = f.input :password_confirmation, required: true
+    .form-actions
+      = f.button :submit, "Sign up", role: 'button'
+  = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,15 +1,16 @@
-%h2 Log in
-%section.form-wrapper
-  = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-    / TODO: UI Kit needs styles for email type (see https://github.com/AusDTO/gov-au-ui-kit/issues/51)
-    /= f.input :email, autofocus: true
-    %p
-      = f.label :email
-      = f.text_field :email
-    %p
-      = f.label :password
-      = f.password_field :password
-    = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
-    = f.button :submit, "Log in", role: 'button'
+%article.content-listing
+  %h2 Log in
+  %section.form-wrapper
+    = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+      / TODO: UI Kit needs styles for email type (see https://github.com/AusDTO/gov-au-ui-kit/issues/51)
+      /= f.input :email, autofocus: true
+      %p
+        = f.label :email
+        = f.text_field :email
+      %p
+        = f.label :password
+        = f.password_field :password
+      = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
+      = f.button :submit, "Log in", role: 'button'
 
-= render "devise/shared/links"
+  = render "devise/shared/links"

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,9 +1,10 @@
-%h2 Resend unlock instructions
-= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
-  = f.error_notification
-  = f.full_error :unlock_token
-  .form-inputs
-    = f.input :email, required: true, autofocus: true
-  .form-actions
-    = f.button :submit, "Resend unlock instructions"
-= render "devise/shared/links"
+%article.content-listing
+  %h2 Resend unlock instructions
+  = simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+    = f.error_notification
+    = f.full_error :unlock_token
+    .form-inputs
+      = f.input :email, required: true, autofocus: true
+    .form-actions
+      = f.button :submit, "Resend unlock instructions"
+  = render "devise/shared/links"

--- a/app/views/ministers/index.html.haml
+++ b/app/views/ministers/index.html.haml
@@ -1,16 +1,18 @@
 - breadcrumb :ministers
 
-%h1
-  Ministers
-%p.abstract
-  The Australian Government's ministers include Cabinet ministers, outer
-  ministers, assistant ministers, ministers assisting and parliamentary
-  secretaries.
-%ul.list-highlighted
-  - ministers.each do |minister|
-    %li
-      %a{href: public_node_path(minister.home_node)}
-        -if minister.prefix.present?
-          %span
-            = minister.prefix
-        = minister.ministry_or_title
+
+%article.content-listing
+  %h1
+    Ministers
+  %p.abstract
+    The Australian Government's ministers include Cabinet ministers, outer
+    ministers, assistant ministers, ministers assisting and parliamentary
+    secretaries.
+  %ul.list-highlighted
+    - ministers.each do |minister|
+      %li
+        %a{href: public_node_path(minister.home_node)}
+          -if minister.prefix.present?
+            %span
+              = minister.prefix
+          = minister.ministry_or_title

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -3,23 +3,26 @@
 - else
   - breadcrumb :public_news_articles
 
-%h1 News
 
-%div.abstract
-  Announcements, media releases, interviews, speeches and more from the Australian Government.
+%article.content-listing
 
-%article#content
-  %ul.list-horizontal
-    - @articles.each do |article|
-      %li
-        %article
-          %h2= link_to article.name, public_node_path(article)
-          %div.meta
-            %time{ datetime: "#{article.release_date}" } #{l(article.release_date, format: :news)}
-            = link_to article.section.name, public_node_path(article.section.home_node), { rel: :author }
-          %p
-            #{article.short_summary}
-          %footer.tags
-            %dl
-              - article.sections.each do |section|
-                %dd= link_to section.name, public_node_path(section.home_node)
+  %h1 News
+
+  %div.abstract
+    Announcements, media releases, interviews, speeches and more from the Australian Government.
+
+  %article#content
+    %ul.list-horizontal
+      - @articles.each do |article|
+        %li
+          %article
+            %h2= link_to article.name, public_node_path(article)
+            %div.meta
+              %time{ datetime: "#{article.release_date}" } #{l(article.release_date, format: :news)}
+              = link_to article.section.name, public_node_path(article.section.home_node), { rel: :author }
+            %p
+              #{article.short_summary}
+            %footer.tags
+              %dl
+                - article.sections.each do |section|
+                  %dd= link_to section.name, public_node_path(section.home_node)

--- a/app/views/sections/index.html.haml
+++ b/app/views/sections/index.html.haml
@@ -1,8 +1,10 @@
 - breadcrumb :public_root
 
-%h1
-  Sections
-%ul
-  - @sections.each do |section|
-    %li
-      = link_to(section.name, section_path(section))
+
+%article.content-listing
+  %h1
+    Sections
+  %ul
+    - @sections.each do |section|
+      %li
+        = link_to(section.name, section_path(section))

--- a/app/views/templates/root_node.html.haml
+++ b/app/views/templates/root_node.html.haml
@@ -1,5 +1,6 @@
 - breadcrumb :public_node, node
-.content-main.home
+
+%article.content-listing
   %section.home-category-list
     %h2 Information and services
 


### PR DESCRIPTION
/departments /news /ministers etc. pages links aren't looking as good as they could be:

![](https://cloud.githubusercontent.com/assets/81432/17209361/06596c9c-5500-11e6-97eb-61b455c5d21d.png)
