### PR TITLE
[SITES-343] Feature/commit and tag in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is influenced by http://keepachangelog.com/.
 
 ## [Unreleased]
 ### Added
+- Include git tag and sha1 on editorial footer
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ credentials for these instances in the environment variables for an application
 that is bound to them.
 
 * SSH into the jump-box that has access to the source RDS instance
-* `pg_dump --no-owner --no-acl -h SRC_RDS_HOST -U SRC_RDS_USERNAME -W SRC_RDS_NAME  > db.sql`
+* `pg_dump --no-owner --no-acl -c -h SRC_RDS_HOST -U SRC_RDS_USERNAME -W SRC_RDS_NAME  > db.sql`
   * You will need to provide the SRC_RDS_PASSWORD
 * If local migrations need to be run on this, SCP the file to your local machine,
   run the necessary migrations, and SCP the file back.

--- a/app/controllers/editorial/editorial_controller.rb
+++ b/app/controllers/editorial/editorial_controller.rb
@@ -5,6 +5,7 @@ module Editorial
     check_authorization
 
     before_action ->() { authorize! :view, :editorial_page }
+    before_action :set_git_vars
 
     layout 'editorial'
 
@@ -12,6 +13,12 @@ module Editorial
       authorize! :view, :editorial_page
       @sections = Section.all.order(:name).select{ |section| can? :read, section }
       @news_section = Section.find_by(name: 'news')
+    end
+
+    private
+    def set_git_vars
+      @version_tag = Rails.configuration.version_tag
+      @version_sha = Rails.configuration.version_sha
     end
   end
 end

--- a/app/views/layouts/editorial.html.haml
+++ b/app/views/layouts/editorial.html.haml
@@ -31,4 +31,8 @@
     %footer{role: "contentinfo"}
       %div.wrapper
         %p
-          &lt;insert footer here&gt;
+          - if @version_tag.present?
+            #{@version_tag}:
+          - if @version_sha.present?
+            #{@version_sha}
+

--- a/bin/deploy-prod.sh
+++ b/bin/deploy-prod.sh
@@ -9,6 +9,12 @@ set -o pipefail
 # echo out each line of the shell as it executes
 set -x
 
+# Update the circle envvars for all apps
+cf set-env gov-au-beta-blue CIRCLE_TAG "$CIRCLE_TAG"
+cf set-env gov-au-beta-blue CIRCLE_SHA1 "$CIRCLE_SHA1"
+cf set-env gov-au-beta-green CIRCLE_TAG "$CIRCLE_TAG"
+cf set-env gov-au-beta-green CIRCLE_SHA1 "$CIRCLE_SHA1"
+
 # Update the blue app
 cf unmap-route gov-au-beta-blue apps.platform.digital.gov.au -n gov-au-beta
 cf push gov-au-beta-blue

--- a/bin/deploy-staging.sh
+++ b/bin/deploy-staging.sh
@@ -6,6 +6,10 @@ set -e
 # Output the commands we run
 set -x
 
+# Update the circle envvars for all apps
+cf set-env gov-au-beta-blue CIRCLE_SHA1 "$CIRCLE_SHA1"
+cf set-env gov-au-beta-green CIRCLE_SHA1 "$CIRCLE_SHA1"
+
 # Update the blue app
 cf unmap-route gov-au-beta-blue apps.staging.digital.gov.au -n gov-au-beta
 cf push gov-au-beta-blue

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,7 @@ Rails.application.configure do
 
   config.active_job.queue_adapter     = :async
   config.active_job.queue_name_prefix = "gov-au-beta_#{Rails.env}"
+
+  config.version_tag = 'dummy_version'
+  config.version_sha = 'dummy_sha'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -97,4 +97,7 @@ Rails.application.configure do
   config.middleware.use '::Rack::Auth::Basic' do |u, p|
     [u, p] == [ENV["HTTP_USERNAME"], ENV["HTTP_PASSWORD"]]
   end
+
+  config.version_tag = ENV['CIRCLE_TAG']
+  config.version_sha = ENV['CIRCLE_SHA1']
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,8 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.active_job.queue_adapter     = :async
   config.active_job.queue_name_prefix = "gov-au-beta_#{Rails.env}"
+
+  # Set mock environment git tag and SHA1 values
+  config.version_tag = 'v1.0.0'
+  config.version_sha = 'abcdefghijkl'
 end

--- a/config/initializers/circle.rb
+++ b/config/initializers/circle.rb
@@ -1,5 +1,0 @@
-Rails.application.configure do
-  # Configure tag and sha1 variables
-  config.version_tag = ENV['CIRCLE_TAG']
-  config.version_sha = ENV['CIRCLE_SHA1']
-end

--- a/config/initializers/circle.rb
+++ b/config/initializers/circle.rb
@@ -1,0 +1,5 @@
+Rails.application.configure do
+  # Configure tag and sha1 variables
+  config.version_tag = ENV['CIRCLE_TAG']
+  config.version_sha = ENV['CIRCLE_SHA1']
+end

--- a/spec/features/editorial_version_spec.rb
+++ b/spec/features/editorial_version_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'editorial version details', type: :feature do
+  Warden.test_mode!
+
+  let!(:root_node) { Fabricate(:root_node) }
+  let!(:section) { Fabricate(:section) }
+  let!(:author) { Fabricate(:user, author_of: section) }
+
+  describe 'editorial#index' do
+    before do
+      login_as author
+      visit editorial_root_path
+    end
+
+    it 'displays version tag and sha' do
+      # Values set in test.rb
+      expect(page).to have_content('v1.0.0')
+      expect(page).to have_content('abcdefghijkl')
+    end
+  end
+end

--- a/spec/features/editorial_version_spec.rb
+++ b/spec/features/editorial_version_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe 'editorial version details', type: :feature do
   Warden.test_mode!
 
-  let!(:root_node) { Fabricate(:root_node) }
   let!(:section) { Fabricate(:section) }
   let!(:author) { Fabricate(:user, author_of: section) }
 


### PR DESCRIPTION
Adds the deployed tag/sha1 to the editorial footer if one is present.

This is supplied by our deploy process - prod will get both the git tag and sha1, whereas staging will only get the sha1.