### PR TITLE
[SITES-542] Whitelist types when creating a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This file is influenced by http://keepachangelog.com/.
 
 - Improved support for IE
 
+- Correctly check for a valid node type when creating nodes
+
 
 ## [v1.0.2] - 2016-08-03
 ### Added

--- a/app/controllers/editorial/editorial_controller.rb
+++ b/app/controllers/editorial/editorial_controller.rb
@@ -15,6 +15,13 @@ module Editorial
       @news_section = Section.find_by(name: 'news')
     end
 
+    class ClientParamError < StandardError
+    end
+
+    rescue_from ClientParamError do
+      head :bad_request
+    end
+
     private
     def set_git_vars
       @version_tag = Rails.configuration.version_tag

--- a/app/controllers/editorial/nodes_controller.rb
+++ b/app/controllers/editorial/nodes_controller.rb
@@ -32,8 +32,7 @@ module Editorial
       configure_defaults!
       authorize! :create_in, @section
 
-      @node_types = [GeneralContent].map do |klass|
-        name = klass.name.underscore
+      @node_types = creatable_type_list.map do |name|
         [I18n.t("domain_model.nodes.#{name}"), name]
       end
 
@@ -86,11 +85,18 @@ module Editorial
 
     private
 
+    def creatable_type_list
+      [GeneralContent].map do |klass|
+        klass.name.underscore
+      end
+    end
+
     def derive_type
       @type_name = params[:type] || 'general_content'
       # Be extra pedantic with user input that is being turned into code
+      # This check MUST be done before the call to #constantize
+      raise ClientParamError unless creatable_type_list.include?(@type_name)
       @type = @type_name.camelize.constantize
-      raise 'Invalid Type' unless @type.superclass.name == 'Node'
       @form_type = form_type(@type)
     end
 

--- a/spec/controllers/editorial/nodes_controller_spec.rb
+++ b/spec/controllers/editorial/nodes_controller_spec.rb
@@ -62,43 +62,40 @@ RSpec.describe Editorial::NodesController, type: :controller do
     #   expect(ContentAnalysisHelper).to receive(:lint).and_return('')
     # end
 
-    context 'when user is authorised' do
-      before { sign_in(author) }
-
-      let(:submission) { Fabricate(:submission) }
-
-      subject do
-        post :create, section_id: section, node: { name: 'Test Node', parent_id: section.home_node.id, short_summary: 'foo' }
-        response
-      end
-
-      it { is_expected.to redirect_to(editorial_section_submission_path(section, Submission.last)) }
-
-      specify 'that a node is created' do
-        expect { subject }.to change(Node, :count).by(1)
-      end
-    end
-
     describe 'to a collaborate node' do
       context 'as authorised user' do
-
-        # before do
-        #   expect(ContentAnalysisHelper).to receive(:lint).and_return('')
-        # end
 
         before { sign_in(author) }
 
         let(:submission) { Fabricate(:submission) }
 
-        subject do
-          post :create, section_id: section, node: { name: 'Test Node', parent_id: section.home_node.id, short_summary: 'foo' }
-          response
+        context 'with valid data' do
+          subject do
+            post :create, params: {
+                section_id: section,
+                node: {name: 'Test Node', parent_id: section.home_node.id, short_summary: 'foo'}
+            }
+            response
+          end
+
+          it { is_expected.to redirect_to(editorial_section_submission_path(section, Submission.last)) }
+
+          specify 'that a node is created' do
+            expect { subject }.to change(Node, :count).by(1)
+          end
         end
 
-        it { is_expected.to redirect_to(editorial_section_submission_path(section, Submission.last)) }
+        context 'with an invalid type' do
+          subject do
+            post :create, params: {
+                section_id: section,
+                node: {name: 'Test node', parent_id: section.home_node.id, short_summary: 'foo'},
+                type: 'bad'
+            }
+            response
+          end
 
-        specify 'that a node is created' do
-          expect { subject }.to change(Node, :count).by(1)
+          it { is_expected.to have_http_status(:bad_request) }
         end
       end
 
@@ -110,8 +107,10 @@ RSpec.describe Editorial::NodesController, type: :controller do
 
         it "does not save the new node" do
           expect{
-            post :create, section_id: section, node: { name: 'Test Node',
-              parent_id: section.home_node.id }
+            post :create, params: {
+                section_id: section,
+                node: { name: 'Test Node', parent_id: section.home_node.id }
+            }
           }.to_not change(Node,:count)
         end
       end
@@ -126,7 +125,7 @@ RSpec.describe Editorial::NodesController, type: :controller do
         end
         it "does not save the new node" do
           expect{
-            post :create, section_id: section, node: { name: 'Test Node' }
+            post :create, params: { section_id: section, node: { name: 'Test Node' } }
           }.to_not change(Node,:count)
         end
       end


### PR DESCRIPTION
Programmers' changelog:
* Move the check for valid node types above the constantize call
* Return a 400 error when there's a bad type
* Remove some deprecation warnings in tests
* Remove duplicated tests