### PR TITLE
[SITES-544] - browser testing IE11 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file is influenced by http://keepachangelog.com/.
 ### Fixed
 - The html title tag reflects the page name
 
+- Improved support for IE
+
 
 ## [v1.0.2] - 2016-08-03
 ### Added

--- a/app/assets/stylesheets/_homepage.scss
+++ b/app/assets/stylesheets/_homepage.scss
@@ -6,6 +6,10 @@ $light-teal: #00a1bb;
   margin: $base-spacing 0;
   padding: $tiny-spacing $base-spacing;
 
+  @include media($tablet) {
+    max-width: ((100% - $list-vertical-gutter * 2) / 3);
+  }
+
   p {
     min-height: 0;
     margin-bottom: $small-spacing;


### PR DESCRIPTION
This PR fixes a bug with IE10/11 ignoring box-sizing on flex-box elements. This was causing layout issue on the category list on the homepage. I have also raised this bug with the UI Kit team https://github.com/AusDTO/gov-au-ui-kit/issues/252

Before
![flexbox-ie11](https://cloud.githubusercontent.com/assets/12635736/17390055/cdc0732e-5a4c-11e6-91ee-0bdbed67dca5.png)

After
![after](https://cloud.githubusercontent.com/assets/12635736/17390065/edb67cd2-5a4c-11e6-91c1-e347303bf4ad.png)

