### PR TITLE
SITES-476 Move content-main class to layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is influenced by http://keepachangelog.com/.
 
 ### Fixed
 - The html title tag reflects the page name
+- Node preview layout in editorial now correctly wraps metadata header
 
 - Improved support for IE
 

--- a/app/views/layouts/editorial.html.haml
+++ b/app/views/layouts/editorial.html.haml
@@ -25,7 +25,7 @@
         %aside.sidebar
           %nav.primary-nav{'aria-label' => 'main navigation'}
             = yield :navbar
-      %article#content{class: "content-main"}
+      %article#content{class: "content-main", role: "main"}
         = render 'alerts'
         = yield
     %footer{role: "contentinfo"}

--- a/app/views/layouts/news_article.html.haml
+++ b/app/views/layouts/news_article.html.haml
@@ -1,5 +1,5 @@
 = inside_layout :application do
-  %article#content{class: "content-main"}
+  %article#content{class: "content-main", role: "main"}
     = yield
 
   = content_for :title do

--- a/app/views/layouts/news_article.html.haml
+++ b/app/views/layouts/news_article.html.haml
@@ -1,5 +1,6 @@
 = inside_layout :application do
-  = yield
+  %article#content{class: "content-main"}
+    = yield
 
   = content_for :title do
     = @node.name

--- a/app/views/layouts/section.html.haml
+++ b/app/views/layouts/section.html.haml
@@ -1,5 +1,5 @@
 = inside_layout :application do
-  %article#content{class: "content-main"}
+  %article#content{class: "content-main", role: "main"}
     = yield
 
   = content_for :after_header do

--- a/app/views/layouts/section.html.haml
+++ b/app/views/layouts/section.html.haml
@@ -1,5 +1,6 @@
 = inside_layout :application do
-  = yield
+  %article#content{class: "content-main"}
+    = yield
 
   = content_for :after_header do
     %div{class: "hero-sml #{hero_class(@section)}"}

--- a/app/views/layouts/section_home.html.haml
+++ b/app/views/layouts/section_home.html.haml
@@ -1,5 +1,5 @@
 = inside_layout :application do
-  %article#content{class: "content-main"}
+  %article#content{class: "content-main", role: "main"}
     = yield
 
   = content_for :after_header do

--- a/app/views/layouts/section_home.html.haml
+++ b/app/views/layouts/section_home.html.haml
@@ -1,5 +1,6 @@
 = inside_layout :application do
-  = yield
+  %article#content{class: "content-main"}
+    = yield
 
   = content_for :after_header do
     %div{class: "hero-med #{hero_class(@section)}"}

--- a/app/views/templates/custom/daylight_savings_act.html.erb
+++ b/app/views/templates/custom/daylight_savings_act.html.erb
@@ -1,7 +1,5 @@
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>Daylight saving and time zones</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -117,4 +115,3 @@
 
 </ul>
 
-</article>

--- a/app/views/templates/custom/daylight_savings_nsw.html.erb
+++ b/app/views/templates/custom/daylight_savings_nsw.html.erb
@@ -1,7 +1,5 @@
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>Daylight saving and time zones</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -116,5 +114,3 @@
   </li>
 
 </ul>
-
-</article>

--- a/app/views/templates/custom/daylight_savings_qld.html.erb
+++ b/app/views/templates/custom/daylight_savings_qld.html.erb
@@ -1,7 +1,5 @@
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>Daylight saving and time zones</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -98,5 +96,3 @@
   </li>
 
 </ul>
-
-</article>

--- a/app/views/templates/custom/daylight_savings_tas.html.erb
+++ b/app/views/templates/custom/daylight_savings_tas.html.erb
@@ -1,7 +1,5 @@
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>Daylight saving and time zones</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -117,4 +115,3 @@
 
 </ul>
 
-</article>

--- a/app/views/templates/custom/daylight_savings_vic.html.erb
+++ b/app/views/templates/custom/daylight_savings_vic.html.erb
@@ -1,8 +1,6 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>Daylight saving and time zones</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -117,5 +115,3 @@
   </li>
 
 </ul>
-
-</article>

--- a/app/views/templates/custom/public_holidays_act.html.erb
+++ b/app/views/templates/custom/public_holidays_act.html.erb
@@ -1,237 +1,233 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
+<h1>Australian public holidays</h1>
 
-  <h1>Australian public holidays</h1>
+<p class="abstract--dates">What state or territory are you in?</p>
 
-  <p class="abstract--dates">What state or territory are you in?</p>
+<div class="sort-container">
+<span>View by:</span>
+<ul class="news-sort-tabs">
+<li><a href="/times-and-dates/australian-public-holidays/new-south-wales">NSW</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/victoria">Vic.</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/queensland">Qld</a></li>
+<li><a href="#">SA</a></li>
+<li><a href="#">WA</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
+<li><a href="#">NT</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/australian-capital-territory" class="active">ACT</a></li>
+</ul>
+</div>
 
-  <div class="sort-container">
-  <span>View by:</span>
-  <ul class="news-sort-tabs">
-  <li><a href="/times-and-dates/australian-public-holidays/new-south-wales">NSW</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/victoria">Vic.</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/queensland">Qld</a></li>
-  <li><a href="#">SA</a></li>
-  <li><a href="#">WA</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
-  <li><a href="#">NT</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/australian-capital-territory" class="active">ACT</a></li>
-  </ul>
-  </div>
+<section class="callout--calendar-event">
+<h2 class="next-event">The next public holiday is:</h2>
+<p><time class="holiday-date" datetime="2016-09-26">Monday 26 September </time><span class="event-name">Family and Community Day</span></p>
+</section>
 
-  <section class="callout--calendar-event">
-  <h2 class="next-event">The next public holiday is:</h2>
-  <p><time class="holiday-date" datetime="2016-09-26">Monday 26 September </time><span class="event-name">Family and Community Day</span></p>
-  </section>
+<h2>2016 public holidays</h2>
 
-  <h2>2016 public holidays</h2>
+<table class="calendar-table">
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-01">Friday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
 
-  <table class="calendar-table">
-    <tr>
-      <th scope="row">
-        <time datetime="2016-01-01">Friday <span>1</span> January</time>
-      </th>
-      <td>New Year's Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-26">Tuesday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-01-26">Tuesday <span>26</span> January</time>
-      </th>
-      <td>Australia Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-14">Monday <span>14</span> March</time>
+    </th>
+    <td>Canberra Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-14">Monday <span>14</span> March</time>
-      </th>
-      <td>Canberra Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-25">Friday <span>25</span> March</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-25">Friday <span>25</span> March</time>
-      </th>
-      <td>Good Friday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-26">Saturday <span>26</span> March</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-26">Saturday <span>26</span> March</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-27">Sunday <span>27</span> March</time>
+    </th>
+    <td>Easter Sunday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-27">Sunday <span>27</span> March</time>
-      </th>
-      <td>Easter Sunday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-28">Monday <span>28</span> March</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-28">Monday <span>28</span> March</time>
-      </th>
-      <td>Easter Monday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-04-25">Monday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-04-25">Monday <span>25</span> April</time>
-      </th>
-      <td>Anzac Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-06-13">Monday <span>13</span> June</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-06-13">Monday <span>13</span> June</time>
-      </th>
-      <td>Queen's Birthday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-09-26">Monday <span>26</span> September</time>
+    </th>
+    <td>Family and Community Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-09-26">Monday <span>26</span> September</time>
-      </th>
-      <td>Family and Community Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-10-03">Monday <span>3</span> October</time>
+    </th>
+    <td>Labour Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-10-03">Monday <span>3</span> October</time>
-      </th>
-      <td>Labour Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-25">Sunday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-25">Sunday <span>25</span> December</time>
-      </th>
-      <td>Christmas Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-26">Monday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-26">Monday <span>26</span> December</time>
-      </th>
-      <td>Boxing Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-27">Tuesday <span>27</span> December</time>
+    </th>
+    <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-27">Tuesday <span>27</span> December</time>
-      </th>
-      <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
-    </tr>
+</table>
 
-  </table>
+<h2>2017 public holidays</h2>
 
-  <h2>2017 public holidays</h2>
+<table class="calendar-table">
 
-  <table class="calendar-table">
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-01">Sunday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-01">Sunday <span>1</span> January</time>
-      </th>
-      <td>New Year's Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-02">Monday <span>2</span> January</time>
+    </th>
+    <td>New Year's Day holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-02">Monday <span>2</span> January</time>
-      </th>
-      <td>New Year's Day holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-26">Thursday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-26">Thursday <span>26</span> January</time>
-      </th>
-      <td>Australia Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-13">Monday <span>13</span> March</time>
+    </th>
+    <td>Canberra Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-13">Monday <span>13</span> March</time>
-      </th>
-      <td>Canberra Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-14">Friday <span>14</span> April</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-14">Friday <span>14</span> April</time>
-      </th>
-      <td>Good Friday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-15">Saturday <span>15</span> April</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-15">Saturday <span>15</span> April</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-16">Sunday <span>16</span> April</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-16">Sunday <span>16</span> April</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-17">Monday <span>17</span> April</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-17">Monday <span>17</span> April</time>
-      </th>
-      <td>Easter Monday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-25">Tuesday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-25">Tuesday <span>25</span> April</time>
-      </th>
-      <td>Anzac Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-06-12">Monday <span>12</span> June</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-06-12">Monday <span>12</span> June</time>
-      </th>
-      <td>Queen's Birthday</td>
-    </tr>
-
-    <tr>
-      <th scope="row">
-        <time datetime="2016-09-25">Monday <span>25</span> September</time>
-      </th>
-      <td>Family and Community Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-09-25">Monday <span>25</span> September</time>
+    </th>
+    <td>Family and Community Day</td>
+  </tr>
 
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-10-02">Monday <span>2</span> October</time>
-      </th>
-      <td>Labour Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-10-02">Monday <span>2</span> October</time>
+    </th>
+    <td>Labour Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-12-25T08:00:00+10:00">Monday <span>25</span> December</time>
-      </th>
-      <td>Christmas Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-25T08:00:00+10:00">Monday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-12-26T08:00:00+10:00">Tuesday <span>26</span> December</time>
-      </th>
-      <td>Boxing Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-26T08:00:00+10:00">Tuesday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
 
-  </table>
-
-</article>
+</table>

--- a/app/views/templates/custom/public_holidays_nsw.html.erb
+++ b/app/views/templates/custom/public_holidays_nsw.html.erb
@@ -1,226 +1,222 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
+<h1>Australian public holidays</h1>
 
-  <h1>Australian public holidays</h1>
+<p class="abstract--dates">What state or territory are you in?</p>
 
-  <p class="abstract--dates">What state or territory are you in?</p>
+<div class="sort-container">
+<span>View by:</span>
+<ul class="news-sort-tabs">
+<li><a href="/times-and-dates/australian-public-holidays/new-south-wales" class="active">NSW</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/victoria">Vic.</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/queensland">Qld</a></li>
+<li><a href="#">SA</a></li>
+<li><a href="#">WA</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
+<li><a href="#">NT</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/australian-capital-territory">ACT</a></li>
+</ul>
+</div>
 
-  <div class="sort-container">
-  <span>View by:</span>
-  <ul class="news-sort-tabs">
-  <li><a href="/times-and-dates/australian-public-holidays/new-south-wales" class="active">NSW</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/victoria">Vic.</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/queensland">Qld</a></li>
-  <li><a href="#">SA</a></li>
-  <li><a href="#">WA</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
-  <li><a href="#">NT</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/australian-capital-territory">ACT</a></li>
-  </ul>
-  </div>
+<section class="callout--calendar-event">
+<h2 class="next-event">The next public holiday is:</h2>
+<p><time class="holiday-date" datetime="2016-10-03">Monday 3 October </time><span class="event-name">Labour Day</span></p>
+</section>
 
-  <section class="callout--calendar-event">
-  <h2 class="next-event">The next public holiday is:</h2>
-  <p><time class="holiday-date" datetime="2016-10-03">Monday 3 October </time><span class="event-name">Labour Day</span></p>
-  </section>
+<h2>2016 public holidays</h2>
 
-  <h2>2016 public holidays</h2>
+<table class="calendar-table">
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-01">Friday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
 
-  <table class="calendar-table">
-    <tr>
-      <th scope="row">
-        <time datetime="2016-01-01">Friday <span>1</span> January</time>
-      </th>
-      <td>New Year's Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-26">Tuesday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-01-26">Tuesday <span>26</span> January</time>
-      </th>
-      <td>Australia Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-25">Friday <span>25</span> March</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-25">Friday <span>25</span> March</time>
-      </th>
-      <td>Good Friday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-26">Saturday <span>26</span> March</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-26">Saturday <span>26</span> March</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-27">Sunday <span>27</span> March</time>
+    </th>
+    <td>Easter Sunday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-27">Sunday <span>27</span> March</time>
-      </th>
-      <td>Easter Sunday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-28">Monday <span>28</span> March</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-28">Monday <span>28</span> March</time>
-      </th>
-      <td>Easter Monday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-04-25">Monday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-04-25">Monday <span>25</span> April</time>
-      </th>
-      <td>Anzac Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-06-13">Monday <span>13</span> June</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-06-13">Monday <span>13</span> June</time>
-      </th>
-      <td>Queen's Birthday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-08-01">Monday <span>1</span> August</time>
+    </th>
+    <td>Bank Holiday
+    <span class="date-info">Applies to banks and certain financial institutions. See the <a href="http://www.legislation.nsw.gov.au/maintop/view/inforce/act+49+2008+cd+0+N">Retail Trading Act 2008</a>.</span>
+    </td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-08-01">Monday <span>1</span> August</time>
-      </th>
-      <td>Bank Holiday
-      <span class="date-info">Applies to banks and certain financial institutions. See the <a href="http://www.legislation.nsw.gov.au/maintop/view/inforce/act+49+2008+cd+0+N">Retail Trading Act 2008</a>.</span>
-      </td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-10-03">Monday <span>3</span> October</time>
+    </th>
+    <td>Labour Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-10-03">Monday <span>3</span> October</time>
-      </th>
-      <td>Labour Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-25">Sunday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-25">Sunday <span>25</span> December</time>
-      </th>
-      <td>Christmas Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-26">Monday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-26">Monday <span>26</span> December</time>
-      </th>
-      <td>Boxing Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-27">Tuesday <span>27</span> December</time>
+    </th>
+    <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-27">Tuesday <span>27</span> December</time>
-      </th>
-      <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
-    </tr>
+</table>
 
-  </table>
+<h2>2017 public holidays</h2>
 
-  <h2>2017 public holidays</h2>
+<table class="calendar-table">
 
-  <table class="calendar-table">
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-01">Sunday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-01">Sunday <span>1</span> January</time>
-      </th>
-      <td>New Year's Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-02">Monday <span>2</span> January</time>
+    </th>
+    <td>New Year's Day holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-02">Monday <span>2</span> January</time>
-      </th>
-      <td>New Year's Day holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-26">Thursday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-26">Thursday <span>26</span> January</time>
-      </th>
-      <td>Australia Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-14">Friday <span>14</span> April</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-14">Friday <span>14</span> April</time>
-      </th>
-      <td>Good Friday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-15">Saturday <span>15</span> April</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-15">Saturday <span>15</span> April</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-16">Sunday <span>16</span> April</time>
+    </th>
+    <td>Easter Sunday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-16">Sunday <span>16</span> April</time>
-      </th>
-      <td>Easter Sunday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-17">Monday <span>17</span> April</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-17">Monday <span>17</span> April</time>
-      </th>
-      <td>Easter Monday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-25">Tuesday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-25">Tuesday <span>25</span> April</time>
-      </th>
-      <td>Anzac Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-07-12">Monday <span>12</span> June</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-07-12">Monday <span>12</span> June</time>
-      </th>
-      <td>Queen's Birthday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-08-07">Monday <span>7</span> August</time>
+    </th>
+    <td>Bank Holiday
+    <span class="date-info">Applies to banks and certain financial institutions. See the <a href="http://www.legislation.nsw.gov.au/maintop/view/inforce/act+49+2008+cd+0+N">Retail Trading Act 2008</a>.</span>
+    </td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-08-07">Monday <span>7</span> August</time>
-      </th>
-      <td>Bank Holiday
-      <span class="date-info">Applies to banks and certain financial institutions. See the <a href="http://www.legislation.nsw.gov.au/maintop/view/inforce/act+49+2008+cd+0+N">Retail Trading Act 2008</a>.</span>
-      </td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-10-02">Monday <span>2</span> October</time>
+    </th>
+    <td>Labour Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-10-02">Monday <span>2</span> October</time>
-      </th>
-      <td>Labour Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-25">Monday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-12-25">Monday <span>25</span> December</time>
-      </th>
-      <td>Christmas Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-26">Tuesday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-12-26">Tuesday <span>26</span> December</time>
-      </th>
-      <td>Boxing Day</td>
-    </tr>
-
-  </table>
-
-</article>
+</table>

--- a/app/views/templates/custom/public_holidays_qld.html.erb
+++ b/app/views/templates/custom/public_holidays_qld.html.erb
@@ -1,208 +1,205 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
+<h1>Australian public holidays</h1>
 
-  <h1>Australian public holidays</h1>
+<p class="abstract--dates">What state or territory are you in?</p>
 
-  <p class="abstract--dates">What state or territory are you in?</p>
+<div class="sort-container">
+<span>View by:</span>
+<ul class="news-sort-tabs">
+<li><a href="/times-and-dates/australian-public-holidays/new-south-wales">NSW</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/victoria">Vic.</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/queensland" class="active">Qld</a></li>
+<li><a href="#">SA</a></li>
+<li><a href="#">WA</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
+<li><a href="#">NT</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/australian-capital-territory">ACT</a></li>
+</ul>
+</div>
 
-  <div class="sort-container">
-  <span>View by:</span>
-  <ul class="news-sort-tabs">
-  <li><a href="/times-and-dates/australian-public-holidays/new-south-wales">NSW</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/victoria">Vic.</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/queensland" class="active">Qld</a></li>
-  <li><a href="#">SA</a></li>
-  <li><a href="#">WA</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
-  <li><a href="#">NT</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/australian-capital-territory">ACT</a></li>
-  </ul>
-  </div>
+<section class="callout--calendar-event">
+<h2 class="next-event">The next public holiday is:</h2>
+<p><time class="holiday-date" datetime="">Monday 3 October </time><span class="event-name">Queen's Birthday</span></p>
+</section>
 
-  <section class="callout--calendar-event">
-  <h2 class="next-event">The next public holiday is:</h2>
-  <p><time class="holiday-date" datetime="">Monday 3 October </time><span class="event-name">Queen's Birthday</span></p>
-  </section>
+<h2>2016 public holidays</h2>
 
-  <h2>2016 public holidays</h2>
+<table class="calendar-table">
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-01">Friday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
 
-  <table class="calendar-table">
-    <tr>
-      <th scope="row">
-        <time datetime="2016-01-01">Friday <span>1</span> January</time>
-      </th>
-      <td>New Year's Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-26">Tuesday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-01-26">Tuesday <span>26</span> January</time>
-      </th>
-      <td>Australia Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-25">Friday <span>25</span> March</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-25">Friday <span>25</span> March</time>
-      </th>
-      <td>Good Friday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-26">Friday <span>26</span> March</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-26">Friday <span>26</span> March</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-28">Monday <span>28</span> March</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-28">Monday <span>28</span> March</time>
-      </th>
-      <td>Easter Monday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-04-25">Monday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-04-25">Monday <span>25</span> April</time>
-      </th>
-      <td>Anzac Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-05-02">Monday <span>2</span> May</time>
+    </th>
+    <td>Labour Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-05-02">Monday <span>2</span> May</time>
-      </th>
-      <td>Labour Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-08-10">Wednesday <span>10</span> August</time>
+    </th>
+    <td>Royal Queensland Show <span class="date-info">Only in the Brisbane area.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-08-10">Wednesday <span>10</span> August</time>
-      </th>
-      <td>Royal Queensland Show <span class="date-info">Only in the Brisbane area.</span></td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-10-03">Monday <span>3</span> October</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-10-03">Monday <span>3</span> October</time>
-      </th>
-      <td>Queen's Birthday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-25">Sunday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-25">Sunday <span>25</span> December</time>
-      </th>
-      <td>Christmas Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-26">Monday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-26">Monday <span>26</span> December</time>
-      </th>
-      <td>Boxing Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-27">Tuesday <span>27</span> December</time>
+    </th>
+    <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-27">Tuesday <span>27</span> December</time>
-      </th>
-      <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
-    </tr>
+</table>
 
-  </table>
+<h2>2017 public holidays</h2>
 
-  <h2>2017 public holidays</h2>
+<table class="calendar-table">
 
-  <table class="calendar-table">
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-01">Sunday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-01">Sunday <span>1</span> January</time>
-      </th>
-      <td>New Year's Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-02">Monday <span>2</span> January</time>
+    </th>
+    <td>New Year's Day holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-02">Monday <span>2</span> January</time>
-      </th>
-      <td>New Year's Day holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-26">Thursday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-26">Thursday <span>26</span> January</time>
-      </th>
-      <td>Australia Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-14">Friday <span>14</span> April</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-14">Friday <span>14</span> April</time>
-      </th>
-      <td>Good Friday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-15">Saturday <span>15</span> April</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-15">Saturday <span>15</span> April</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-17">Monday <span>17</span> April</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-17">Monday <span>17</span> April</time>
-      </th>
-      <td>Easter Monday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-25">Tuesday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-25">Tuesday <span>25</span> April</time>
-      </th>
-      <td>Anzac Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-05-01">Tuesday <span>1</span> May</time>
+    </th>
+    <td>Labour Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-05-01">Tuesday <span>1</span> May</time>
-      </th>
-      <td>Labour Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-08-16">Wednesday <span>16</span> August</time>
+    </th>
+    <td>Royal Queensland Show <span class="date-info">Only in the Brisbane area.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-08-16">Wednesday <span>16</span> August</time>
-      </th>
-      <td>Royal Queensland Show <span class="date-info">Only in the Brisbane area.</span></td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-10-02">Monday <span>2</span> October</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-10-02">Monday <span>2</span> October</time>
-      </th>
-      <td>Queen's Birthday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-25">Monday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-12-25">Monday <span>25</span> December</time>
-      </th>
-      <td>Christmas Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-26">Tuesday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-12-26">Tuesday <span>26</span> December</time>
-      </th>
-      <td>Boxing Day</td>
-    </tr>
+</table>
 
-  </table>
-
-</article>

--- a/app/views/templates/custom/public_holidays_tas.html.erb
+++ b/app/views/templates/custom/public_holidays_tas.html.erb
@@ -1,8 +1,6 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>Australian public holidays</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -268,4 +266,3 @@
 
 </table>
 
-</article>

--- a/app/views/templates/custom/public_holidays_vic.html.erb
+++ b/app/views/templates/custom/public_holidays_vic.html.erb
@@ -1,235 +1,231 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
+<h1>Australian public holidays</h1>
 
-  <h1>Australian public holidays</h1>
+<p class="abstract--dates">What state or territory are you in?</p>
 
-  <p class="abstract--dates">What state or territory are you in?</p>
+<div class="sort-container">
+<span>View by:</span>
+<ul class="news-sort-tabs">
+<li><a href="/times-and-dates/australian-public-holidays/new-south-wales">NSW</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/victoria" class="active">Vic.</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/queensland">Qld</a></li>
+<li><a href="#">SA</a></li>
+<li><a href="#">WA</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
+<li><a href="#">NT</a></li>
+<li><a href="/times-and-dates/australian-public-holidays/australian-capital-territory">ACT</a></li>
+</ul>
+</div>
 
-  <div class="sort-container">
-  <span>View by:</span>
-  <ul class="news-sort-tabs">
-  <li><a href="/times-and-dates/australian-public-holidays/new-south-wales">NSW</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/victoria" class="active">Vic.</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/queensland">Qld</a></li>
-  <li><a href="#">SA</a></li>
-  <li><a href="#">WA</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/tasmania">Tas.</a></li>
-  <li><a href="#">NT</a></li>
-  <li><a href="/times-and-dates/australian-public-holidays/australian-capital-territory">ACT</a></li>
-  </ul>
-  </div>
+<section class="callout--calendar-event">
+<h2 class="next-event">The next public holiday is:</h2>
+<p><time class="holiday-date" datetime="2016-09-30">Friday 30 September </time><span class="event-name">Grand Final Friday</span></p>
+</section>
 
-  <section class="callout--calendar-event">
-  <h2 class="next-event">The next public holiday is:</h2>
-  <p><time class="holiday-date" datetime="2016-09-30">Friday 30 September </time><span class="event-name">Grand Final Friday</span></p>
-  </section>
+<h2>2016 public holidays</h2>
 
-  <h2>2016 public holidays</h2>
+<table class="calendar-table">
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-01">Friday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
 
-  <table class="calendar-table">
-    <tr>
-      <th scope="row">
-        <time datetime="2016-01-01">Friday <span>1</span> January</time>
-      </th>
-      <td>New Year's Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-01-26">Tuesday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-01-26">Tuesday <span>26</span> January</time>
-      </th>
-      <td>Australia Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-03-14">Monday <span>14</span> March</time>
+    </th>
+    <td>Labour Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-03-14">Monday <span>14</span> March</time>
-      </th>
-      <td>Labour Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-25">Friday <span>25</span> March</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-25">Friday <span>25</span> March</time>
-      </th>
-      <td>Good Friday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-26">Saturday <span>26</span> March</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-26">Saturday <span>26</span> March</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-27">Sunday <span>27</span> March</time>
+    </th>
+    <td>Easter Sunday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-27">Sunday <span>27</span> March</time>
-      </th>
-      <td>Easter Sunday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-03-28">Monday <span>28</span> March</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-03-28">Monday <span>28</span> March</time>
-      </th>
-      <td>Easter Monday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-04-25">Monday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-04-25">Monday <span>25</span> April</time>
-      </th>
-      <td>Anzac Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-06-13">Monday <span>13</span> June</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-06-13">Monday <span>13</span> June</time>
-      </th>
-      <td>Queen's Birthday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-09-01">Friday <span>30</span> September</time>
+    </th>
+    <td>Grand Final Friday
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-09-01">Friday <span>30</span> September</time>
-      </th>
-      <td>Grand Final Friday
+    </td>
+  </tr>
 
-      </td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-11-01">Monday <span>1</span> November</time>
+    </th>
+    <td>Melbourne Cup
+    <span class="date-info">A public holiday across all of Victoria, unless alternate local holiday has been arranged by non-metro council.</span>
+    </td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-11-01">Monday <span>1</span> November</time>
-      </th>
-      <td>Melbourne Cup
-      <span class="date-info">A public holiday across all of Victoria, unless alternate local holiday has been arranged by non-metro council.</span>
-      </td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-25">Sunday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-25">Sunday <span>25</span> December</time>
-      </th>
-      <td>Christmas Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-26">Monday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-26">Monday <span>26</span> December</time>
-      </th>
-      <td>Boxing Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-12-27">Tuesday <span>27</span> December</time>
+    </th>
+    <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-12-27">Tuesday <span>27</span> December</time>
-      </th>
-      <td>Christmas Day holiday <span class="date-info">Christmas Day falls on a Sunday, so this is also a public holiday.</span></td>
-    </tr>
+</table>
 
-  </table>
+<h2>2017 public holidays</h2>
 
-  <h2>2017 public holidays</h2>
+<table class="calendar-table">
 
-  <table class="calendar-table">
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-01">Sunday <span>1</span> January</time>
+    </th>
+    <td>New Year's Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-01">Sunday <span>1</span> January</time>
-      </th>
-      <td>New Year's Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-02">Monday <span>2</span> January</time>
+    </th>
+    <td>New Year's Day holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-02">Monday <span>2</span> January</time>
-      </th>
-      <td>New Year's Day holiday <span class="date-info">New Year's Day falls on a Sunday, so this is also a public holiday.</span></td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-01-26">Thursday <span>26</span> January</time>
+    </th>
+    <td>Australia Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-01-26">Thursday <span>26</span> January</time>
-      </th>
-      <td>Australia Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-03-13">Monday <span>13</span> March</time>
+    </th>
+    <td>Labour Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-03-13">Monday <span>13</span> March</time>
-      </th>
-      <td>Labour Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-14">Friday <span>14</span> April</time>
+    </th>
+    <td>Good Friday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-14">Friday <span>14</span> April</time>
-      </th>
-      <td>Good Friday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-15">Saturday <span>15</span> April</time>
+    </th>
+    <td>Easter Saturday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-15">Saturday <span>15</span> April</time>
-      </th>
-      <td>Easter Saturday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-16">Sunday <span>16</span> April</time>
+    </th>
+    <td>Easter Sunday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-16">Sunday <span>16</span> April</time>
-      </th>
-      <td>Easter Sunday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-17">Monday <span>17</span> April</time>
+    </th>
+    <td>Easter Monday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-17">Monday <span>17</span> April</time>
-      </th>
-      <td>Easter Monday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-04-25">Tuesday <span>25</span> April</time>
+    </th>
+    <td>Anzac Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-04-25">Tuesday <span>25</span> April</time>
-      </th>
-      <td>Anzac Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-07-12">Monday <span>12</span> June</time>
+    </th>
+    <td>Queen's Birthday</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-07-12">Monday <span>12</span> June</time>
-      </th>
-      <td>Queen's Birthday</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2016-11-07">Monday <span>7</span> November</time>
+    </th>
+    <td>Melbourne Cup
+    <span class="date-info">A public holiday across all of Victoria, unless alternate local holiday has been arranged by non-metro council.</span>
+    </td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2016-11-07">Monday <span>7</span> November</time>
-      </th>
-      <td>Melbourne Cup
-      <span class="date-info">A public holiday across all of Victoria, unless alternate local holiday has been arranged by non-metro council.</span>
-      </td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-25">Monday <span>25</span> December</time>
+    </th>
+    <td>Christmas Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-12-25">Monday <span>25</span> December</time>
-      </th>
-      <td>Christmas Day</td>
-    </tr>
+  <tr>
+    <th scope="row">
+      <time datetime="2017-12-26">Tuesday <span>26</span> December</time>
+    </th>
+    <td>Boxing Day</td>
+  </tr>
 
-    <tr>
-      <th scope="row">
-        <time datetime="2017-12-26">Tuesday <span>26</span> December</time>
-      </th>
-      <td>Boxing Day</td>
-    </tr>
-
-  </table>
-
-</article>
+</table>

--- a/app/views/templates/custom/school_holidays_act.html.erb
+++ b/app/views/templates/custom/school_holidays_act.html.erb
@@ -1,8 +1,6 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>School holidays and term dates</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -177,4 +175,3 @@
 
 </ul>
 
-</article>

--- a/app/views/templates/custom/school_holidays_nsw.html.erb
+++ b/app/views/templates/custom/school_holidays_nsw.html.erb
@@ -1,8 +1,6 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>School holidays and term dates</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -181,4 +179,3 @@
 
 </ul>
 
-</article>

--- a/app/views/templates/custom/school_holidays_qld.html.erb
+++ b/app/views/templates/custom/school_holidays_qld.html.erb
@@ -1,8 +1,6 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>School holidays and term dates</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -181,4 +179,3 @@ one week early on Monday 4 December 2017.</span></p>
 
 </ul>
 
-</article>

--- a/app/views/templates/custom/school_holidays_tas.html.erb
+++ b/app/views/templates/custom/school_holidays_tas.html.erb
@@ -1,8 +1,6 @@
 <% content_for :title do %><%= node.name %><% end %>
 <%- breadcrumb :public_node, node %>
 
-<article class="content-main" id="content" role="main">
-
 <h1>School holidays and term dates</h1>
 
 <p class="abstract--dates">What state or territory are you in?</p>
@@ -176,5 +174,3 @@
   </li>
 
 </ul>
-
-</article>

--- a/app/views/templates/general_content.html.haml
+++ b/app/views/templates/general_content.html.haml
@@ -1,17 +1,16 @@
 = content_for :title do
   =node.name
 
-%article#content{class: "content-main"}
-  - breadcrumb :public_node, node
+- breadcrumb :public_node, node
 
-  %h1
-    =node.name
+%h1
+  =node.name
 
-  %div.abstract
-    %p
-      =node.short_summary
-      - if node.summary
-        != markdown_content node.summary
+%div.abstract
+  %p
+    =node.short_summary
+    - if node.summary
+      != markdown_content node.summary
 
-  = render partial: 'templates/toc', locals: {content_body: node.content_body, depth: node.options.toc}
-  = render partial: 'templates/content_body', object: node.content_body
+= render partial: 'templates/toc', locals: {content_body: node.content_body, depth: node.options.toc}
+= render partial: 'templates/content_body', object: node.content_body

--- a/app/views/templates/news_article.html.haml
+++ b/app/views/templates/news_article.html.haml
@@ -1,31 +1,30 @@
 = content_for :title do
   =node.name
-  
-%article#content{class: "content-main"}
-  - breadcrumb :public_news_article, node
 
-  %dl.list-horizontal
-    %div.tags
-      - node.related_sections.each do |distribution|
-        %dd= link_to distribution.name, public_node_path(distribution.home_node)
+- breadcrumb :public_news_article, node
 
-  %h1
-    =node.name
+%dl.list-horizontal
+  %div.tags
+    - node.related_sections.each do |distribution|
+      %dd= link_to distribution.name, public_node_path(distribution.home_node)
 
-  %div.abstract
-    %p
-      =node.short_summary
-      - if node.summary
-        != markdown_content node.summary
+%h1
+  =node.name
 
-  %ul.announcement-info
-    - if node.release_date
-      %li Published date: #{l(node.release_date, format: :news)}
-    %li
-      Published by:
-      %a= link_to(node.section.name, public_node_path(node.section.home_node))
+%div.abstract
+  %p
+    =node.short_summary
+    - if node.summary
+      != markdown_content node.summary
+
+%ul.announcement-info
+  - if node.release_date
+    %li Published date: #{l(node.release_date, format: :news)}
+  %li
+    Published by:
+    %a= link_to(node.section.name, public_node_path(node.section.home_node))
 
 
-  = render partial: 'templates/content_body', object: node.content_body
+= render partial: 'templates/content_body', object: node.content_body
 
-  =@hierarchy
+=@hierarchy

--- a/app/views/templates/node.html.haml
+++ b/app/views/templates/node.html.haml
@@ -1,12 +1,12 @@
 = content_for :title do
   =node.name
-%article#content{class: "content-main"}
-  - breadcrumb :public_node, node
 
-  %h1
-    =node.name
+- breadcrumb :public_node, node
 
-  = render partial: 'templates/content_body', object: node.content_body
+%h1
+  =node.name
 
-  %p
-    =@hierarchy
+= render partial: 'templates/content_body', object: node.content_body
+
+%p
+  =@hierarchy

--- a/app/views/templates/section_home.html.haml
+++ b/app/views/templates/section_home.html.haml
@@ -1,30 +1,30 @@
 = content_for :title do
   =node.name
-%article#content{class: "content-main"}
-  - breadcrumb :public_node, node
 
-  %div.abstract
-    %p
-      =node.short_summary
-      - if node.summary
-        != markdown_content node.summary
+- breadcrumb :public_node, node
 
-  = render partial: 'templates/related_topics'
-  = render partial: 'templates/content_body', object: node.content_body
+%div.abstract
+  %p
+    =node.short_summary
+    - if node.summary
+      != markdown_content node.summary
 
-  %h2 News
-  %p Announcements, media releases, interviews, speeches and more.
+= render partial: 'templates/related_topics'
+= render partial: 'templates/content_body', object: node.content_body
 
-  - if @news.any?
-    %ul.list-vertical--thirds
-      - @news.each do |news|
-        %li
-          %article
-            %h3= link_to news.name, public_node_path(news)
-            .meta= l(news.release_date, format: :news)
-    %p
-      =link_to 'More news', section_news_articles_path(section: @section.home_node.slug)
-  - else
-    %p No current news articles
+%h2 News
+%p Announcements, media releases, interviews, speeches and more.
 
-  = render partial: 'templates/related_ministers', object: @section.try(:ministers)
+- if @news.any?
+  %ul.list-vertical--thirds
+    - @news.each do |news|
+      %li
+        %article
+          %h3= link_to news.name, public_node_path(news)
+          .meta= l(news.release_date, format: :news)
+  %p
+    =link_to 'More news', section_news_articles_path(section: @section.home_node.slug)
+- else
+  %p No current news articles
+
+= render partial: 'templates/related_ministers', object: @section.try(:ministers)


### PR DESCRIPTION
The Metadata heading is now correctly shown below the preview.

![image](https://cloud.githubusercontent.com/assets/2324569/17390941/ee288572-5a54-11e6-9487-8a266952f2af.png)
