### PR TITLE
Fix news date formatting on home page

### DIFF
--- a/app/views/templates/root_node.html.haml
+++ b/app/views/templates/root_node.html.haml
@@ -62,7 +62,7 @@
         %li
           %article
             %h3= link_to news.name, public_node_path(news)
-            .meta= news.release_date
+            .meta= l(news.release_date, format: :news)
     =link_to 'All news', news_articles_path, :class => "see-more"
 
   %section.government-links


### PR DESCRIPTION
## Old
![image](https://cloud.githubusercontent.com/assets/4583474/17392155/c1291da2-5a5e-11e6-9cfb-34cbeecaef8d.png)

## New
![image](https://cloud.githubusercontent.com/assets/4583474/17392164/d71e8c64-5a5e-11e6-83c3-11417edf4784.png)

Note: This was fixed but seems to have been lost in a bad merge.