### PR TITLE
[SITES-343] Feature/commit and tag in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ This file is influenced by http://keepachangelog.com/.
 - Include git tag and sha1 on editorial footer
 
 ### Changed
-- Truncated SHA on editorial page and improved clarity around version
 
 ### Fixed
 - The html title tag reflects the page name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is influenced by http://keepachangelog.com/.
 - Include git tag and sha1 on editorial footer
 
 ### Changed
+- Truncated SHA on editorial page and improved clarity around version
 
 ### Fixed
 - The html title tag reflects the page name

--- a/app/controllers/editorial/editorial_controller.rb
+++ b/app/controllers/editorial/editorial_controller.rb
@@ -18,7 +18,7 @@ module Editorial
     private
     def set_git_vars
       @version_tag = Rails.configuration.version_tag
-      @version_sha = Rails.configuration.version_sha
+      @version_sha = Rails.configuration.version_sha[0..6]
     end
   end
 end

--- a/app/views/layouts/editorial.html.haml
+++ b/app/views/layouts/editorial.html.haml
@@ -31,6 +31,7 @@
     %footer{role: "contentinfo"}
       %div.wrapper
         %p
+          Version:
           - if @version_tag.present?
             #{@version_tag}:
           - if @version_sha.present?

--- a/spec/features/editorial_version_spec.rb
+++ b/spec/features/editorial_version_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'editorial version details', type: :feature do
     it 'displays version tag and sha' do
       # Values set in test.rb
       expect(page).to have_content('v1.0.0')
-      expect(page).to have_content('abcdefghijkl')
+      expect(page).to have_content('abcdefghijkl'[0..6])
     end
   end
 end


### PR DESCRIPTION
Because it'll be rejected in QA

* improved clarity around the version blob in the footer
* truncated hash

![image](https://cloud.githubusercontent.com/assets/5369670/17421839/71302a38-5af0-11e6-80ff-0b14d5b9141a.png)
