### PR TITLE
[SITES-554] Add accessibility tests and fix accessibility errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ bower.json
 engines/synergy/spec/dummy/db/*.sqlite3
 engines/synergy/spec/dummy/log
 /vendor/assets/images.zip
+
+# ignore sitemap because it's based on the database
+public/sitemap.xml*
+public/sitemaps/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,16 @@ This file is influenced by http://keepachangelog.com/.
 ## [Unreleased]
 ### Added
 - Include git tag and sha1 on editorial footer
+- Added automated accessibility tests
 
 ### Changed
 
 ### Fixed
 - The html title tag reflects the page name
 - Node preview layout in editorial now correctly wraps metadata header
-
 - Improved support for IE
-
 - Correctly check for a valid node type when creating nodes
+- Fixed some accessibility issues
 
 
 ## [v1.0.2] - 2016-08-03

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'prometheus-client'
 gem 'html2haml'
 gem 'rubyzip', '>= 1.0.0'
 gem 'ruby-sun-times', require: 'sun_times'
+gem 'sitemap_generator'
 
 #TODO switch to thoughtbot's latest release once PRs are merged & released:
 # - https://github.com/thoughtbot/administrate/pull/580 # sidebar config
@@ -95,6 +96,8 @@ group :test do
   gem 'launchy'
   gem 'codeclimate-test-reporter', require: nil
   gem 'with_model', '~> 1.2.1'
+  gem 'axe-matchers'
+  gem 'capybara-webkit'
 end
 
 platforms :mingw, :mswin do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,9 @@ GEM
       mail (> 2.2.5)
       mime-types
       xml-simple
+    axe-matchers (1.3.1)
+      dumb_delegator (~> 0.8)
+      virtus (~> 1.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -123,6 +126,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.11.1)
+      capybara (>= 2.3.0, < 2.8.0)
+      json
     cf-app-utils (0.6)
     codeclimate-test-reporter (0.5.2)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -183,6 +189,7 @@ GEM
       dry-monads (>= 0.0.1)
       ice_nine (~> 0.11)
       inflecto (~> 0.0.0, >= 0.0.2)
+    dumb_delegator (0.8.0)
     enumerize (1.1.1)
       activesupport (>= 3.2)
     equalizer (0.0.11)
@@ -385,6 +392,8 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    sitemap_generator (5.1.0)
+      builder
     slop (3.6.0)
     spinach (0.8.10)
       colorize
@@ -437,11 +446,13 @@ DEPENDENCIES
   administrate!
   andand
   aws-ses (~> 0.6.0)
+  axe-matchers
   bourbon
   bower-rails (~> 0.10.0)
   byebug
   cancancan
   capybara (~> 2.7)
+  capybara-webkit
   cf-app-utils
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
@@ -496,6 +507,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   simple_form!
   simplecov (~> 0.11.2)
+  sitemap_generator
   spinach (~> 0.8.10)
   storext!
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
 # logs etc. in /usr/local/var/postgres/
 
+# install qt for running javascript-enabled feature tests
+brew install qt
+
 # install deps
 bundle install
 

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -40,7 +40,5 @@
             = link_to article.section.name, public_node_path(article.section.home_node), { rel: :author }
           %p
             #{article.short_summary}
-          %footer.tags
-            %dl
-              - article.related_sections.each do |section|
-                %dd= link_to section.name, public_node_path(section.home_node)
+          %footer
+            = render partial: 'templates/related_sections', locals: {node: article}

--- a/app/views/templates/_related_ministers.html.haml
+++ b/app/views/templates/_related_ministers.html.haml
@@ -2,12 +2,13 @@
   %h2 Our ministers
   %ul.list-horizontal
     - related_ministers.each do |minister|
+      - id = "minister-summary-#{minister.name.parameterize}"
       %li
         %figure
-          %img{src: minister.image_url}
+          %img{src: minister.image_url, alt: '', 'aria-labelledBy' => id}
         %article
           %h3
             =link_to(minister.name, public_node_path(minister.home_node))
-          %p
+          %p{id: id}
             %strong
               = minister.summary

--- a/app/views/templates/_related_sections.html.haml
+++ b/app/views/templates/_related_sections.html.haml
@@ -1,0 +1,7 @@
+-# locals: node : NewsArticle
+- if node.related_sections.any?
+  %div.tags
+    %dl
+      %dt Tags:
+      - node.related_sections.each do |section|
+        %dd= link_to section.name, public_node_path(section.home_node)

--- a/app/views/templates/news_article.html.haml
+++ b/app/views/templates/news_article.html.haml
@@ -3,10 +3,8 @@
 
 - breadcrumb :public_news_article, node
 
-%dl.list-horizontal
-  %div.tags
-    - node.related_sections.each do |distribution|
-      %dd= link_to distribution.name, public_node_path(distribution.home_node)
+%div.list-horizontal
+  = render partial: 'templates/related_sections', locals: {node: node}
 
 %h1
   =node.name

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  Rails.application.routes.default_url_options = { host: 'localhost', port: 3000 }
 
   config.action_mailer.delivery_method = :letter_opener
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,6 +70,10 @@ Rails.application.configure do
     protocol: 'https',
     host: ENV["APP_DOMAIN"]
   }
+  Rails.application.routes.default_url_options = {
+      protocol: 'https',
+      host: ENV["APP_DOMAIN"]
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,7 @@ Rails.application.configure do
 
   # Add default url options so *_url helpers work in test
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  Rails.application.routes.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,0 +1,31 @@
+# See https://github.com/kjvarga/sitemap_generator for more information on this config file
+
+SitemapGenerator::Sitemap.default_host = root_url
+
+# TODO: Change to true before going live
+SitemapGenerator::Sitemap.compress = false
+
+# get access to NodesHelper#public_node_path
+SitemapGenerator::Interpreter.send :include, NodesHelper
+
+SitemapGenerator::Sitemap.create do
+  group(filename: :public, sitemaps_path: 'sitemaps/') do
+    add root_path
+    add departments_path
+    add ministers_path
+    add news_articles_path
+    SectionHome.published.find_each do |section_home|
+      add section_news_articles_path(section_home.slug)
+    end
+    Node.published.find_each do |node|
+      unless node.class == RootNode
+        add public_node_path(node)
+      end
+    end
+  end
+
+  group(filename: :editorial, sitemaps_path: 'sitemaps/') do
+    # TODO populate this properly
+    add editorial_root_path
+  end
+end

--- a/lib/tasks/smoke.rake
+++ b/lib/tasks/smoke.rake
@@ -1,0 +1,14 @@
+# A selection of tests to smoke-test a site
+namespace :smoke do
+  begin
+    require 'rspec/core/rake_task'
+    desc 'Run accessibility tests against an external site'
+    RSpec::Core::RakeTask.new(:accessibility) do |t|
+      unless ENV.has_key?('ACCESSIBILITY_TEST_URL') or ENV.has_key?('ACCESSIBILITY_TEST_SITEMAP')
+        raise 'Please define either ACCESSIBILITY_TEST_URL or ACCESSIBILITY_TEST_SITEMAP'
+      end
+      t.pattern = 'spec/features/accessibility_spec.rb'
+    end
+  rescue LoadError
+  end
+end

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+require 'open-uri'
+
+RSpec.describe 'accessibility:', :js, :truncate, :nodes_helper, type: :feature do
+
+  Warden.test_mode!
+  WebMock.allow_net_connect!
+
+  shared_examples 'is accessible' do |url, as_code|
+    it "#{url} is accessible" do
+      if as_code
+        url = eval(url)
+      end
+      visit url
+      expect(page.status_code).to eq(200)
+      # TODO: Remove skip clause once ui-kit colours are updated
+      # See https://github.com/AusDTO/gov-au-ui-kit/issues/271
+      expect(page).to be_accessible.according_to(:wcag2a, :wcag2aa).skipping('color-contrast')
+    end
+  end
+
+  shared_examples 'is accessible sitemap' do |uri|
+    sitemap = open(uri) { |f| Nokogiri::XML(f) }
+    sitemap.css('url loc').each do |loc_block|
+      url = loc_block.content
+      if ENV.has_key?('ACCESSIBILITY_TEST_HOST')
+        url = url.gsub('http://localhost:3000', ENV['ACCESSIBILITY_TEST_HOST'])
+      end
+      include_examples 'is accessible', url
+    end
+    sitemap.css('sitemap loc').each do |sitemap_block|
+      url = sitemap_block.content
+      if ENV.has_key?('ACCESSIBILITY_TEST_HOST')
+        url = url.gsub('http://localhost:3000', ENV['ACCESSIBILITY_TEST_HOST'])
+      end
+      include_examples 'is accessible sitemap', url
+    end
+  end
+
+  if ENV.has_key?('ACCESSIBILITY_TEST_URL')
+
+    # Test accessibility of a given URL
+    include_examples 'is accessible', ENV['ACCESSIBILITY_TEST_URL']
+
+  elsif ENV.has_key?('ACCESSIBILITY_TEST_SITEMAP')
+
+    # Test accessibility of all urls in a sitemap
+    include_examples 'is accessible sitemap', ENV['ACCESSIBILITY_TEST_SITEMAP']
+
+  else
+
+    # Test accessibility of test data
+    let!(:minister) { Fabricate(:minister) }
+    let!(:department) { Fabricate(:department, ministers: [minister]) }
+    let!(:topic) { Fabricate(:topic) }
+    let!(:news_article) { Fabricate(:news_article, section: department, sections: [department, minister]) }
+    let!(:general_content) { Fabricate(:general_content) }
+    include_examples 'is accessible', 'root_path', true
+    include_examples 'is accessible', 'departments_path', true
+    include_examples 'is accessible', 'ministers_path', true
+    include_examples 'is accessible', 'news_articles_path', true
+    include_examples 'is accessible', 'public_node_path(news_article)', true
+    include_examples 'is accessible', 'public_node_path(department.home_node)', true
+    include_examples 'is accessible', 'public_node_path(minister.home_node)', true
+    include_examples 'is accessible', 'public_node_path(topic.home_node)', true
+    include_examples 'is accessible', 'public_node_path(general_content)', true
+
+  end
+end

--- a/spec/lib/synergy/cms_import_spec.rb
+++ b/spec/lib/synergy/cms_import_spec.rb
@@ -3,7 +3,7 @@ require 'pry'
 
 require 'synergy/cms_import'
 
-RSpec.describe Synergy::CMSImport, :type => :cms_import do
+RSpec.describe Synergy::CMSImport, :type => :cms_import, :truncate => true do
 
   class DummyCMSAdapter
     attr_reader :section

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,12 +45,12 @@ RSpec.configure do |config|
 
   # Request specs cannot use a transaction because Capybara runs in a
   # separate thread with a different database connection.
-  config.before type: :cms_import do
+  config.before truncate: true do
     DatabaseCleaner.strategy = :truncation
   end
 
   # Reset so other non-request specs don't have to deal with slow truncation.
-  config.after type: :cms_import  do
+  config.after truncate: true  do
     DatabaseCleaner.strategy = :transaction
   end
 
@@ -61,6 +61,8 @@ RSpec.configure do |config|
   config.after do
     DatabaseCleaner.clean
   end
+
+  config.include NodesHelper, nodes_helper: true
 
   #
   # You can disable this behaviour by removing the line below, and instead

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,9 +18,11 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'webmock/rspec'
 require 'capybara/rspec'
+require 'capybara/webkit'
 require 'simplecov'
 require 'codeclimate-test-reporter'
 require 'with_model'
+require 'axe/rspec'
 
 # save to CircleCI's artifacts directory if we're on CircleCI
 if ENV['CIRCLE_ARTIFACTS']
@@ -31,6 +33,14 @@ end
 # push test coverage report to codeclimate.com
 WebMock.disable_net_connect!(:allow => "codeclimate.com")
 CodeClimate::TestReporter.start
+
+Capybara.javascript_driver = :webkit
+
+# Default behaviour is to raise a warning for unknown urls
+# Until such time as we get any other requirements, just let everything through
+Capybara::Webkit.configure do |config|
+  config.allow_unknown_urls
+end
 
 RSpec.configure do |config|
 


### PR DESCRIPTION
Notes:
* Running `rspec` will test accessibility of a couple of dummy pages
* Running `rake sitemap:create` will create a sitemap of the public site in `public/sitemaps/public.xml` and a dummy editorial sitemap in `public/sitemaps/editorial.xml` as well as the index `public/sitemap.xml`
* Running `ACCESSIBILITY_TEST_SITEMAP='public/sitemaps/public.xml' rake smoke:accessibility` will test accessibility of all pages listed in the sitemap.
* Fixes accessibility issues with the news tags and alt-text for minister images.