### PR TITLE
SITES-578 SITES-609 More robust scrubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ This file is influenced by http://keepachangelog.com/.
 - Added collecting test metadata for CircleCI
 - Added ability to mark pages as placeholders that appear in navigation
 
-
 ### Changed
-- Upgrade UI kit to v1.7.3
+- Upgrade UI kit to v1.7.4
 - Removed optional content editors like editor.md and trumbowyg
 - Deleted summary text on Minister and Departments listing pages
-
+- Improvements to the database scrubbing script
 
 ### Fixed
 - The page preview in the editor does not allow javascript to be previewed

--- a/bin/scrub.rb
+++ b/bin/scrub.rb
@@ -7,20 +7,32 @@ USERS_BEGIN = /^COPY users \(/
 USERS_END = /^\\\./
 
 scrubbing = false
+scrubbed = false
 idx = 0
+col_index = {}
 
 while line = gets
   if line =~ USERS_BEGIN
     scrubbing = true
+    scrubbed = true
+    columns = line.match(/\((.*)\)/).captures[0]
+    columns.split(/\s*,\s*/).each_with_index do |val, index|
+      col_index[val.to_sym] =  index
+    end
   else
     scrubbing = false if line =~ USERS_END
 
     if scrubbing
       parts = line.split /\t/
-      parts[1] = "user-#{idx}@digital.gov.au"
-      parts[2] = 'REDACTED'
-      parts[13] = "User #{idx}"
-      parts[14] = 'Nameless'
+      parts[col_index[:email]] = "user-#{idx}@digital.gov.au"
+      parts[col_index[:encrypted_password]] = 'REDACTED'
+      parts[col_index[:reset_password_token]] = '\N'
+      parts[col_index[:current_sign_in_ip]] = '127.0.0.1'
+      parts[col_index[:last_sign_in_ip]] = '127.0.0.1'
+      parts[col_index[:first_name]] = "User #{idx}"
+      parts[col_index[:last_name]] = 'Nameless'
+      parts[col_index[:confirmation_token]] = '\N'
+      parts[col_index[:unconfirmed_email]] = '\N'
       line = parts.join "\t"
       idx += 1
     end
@@ -28,3 +40,5 @@ while line = gets
 
   puts line
 end
+
+raise 'Not scrubbed' if scrubbing || !scrubbed


### PR DESCRIPTION
No longer assumes column order, and raises error if scrubbing does not occur.
Also now scrub IPs, reset tokens, and confirmation tokens.