### PR TITLE
Bugfix/login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This file is influenced by http://keepachangelog.com/.
 ### Fixed
 - The page preview in the editor does not allow javascript to be previewed
 - Don't let admins search on password hash
-
+- Update visual design of admin sign-in form
 
 ## [v1.0.3] - 2016-08-16
 ### Added

--- a/app/assets/stylesheets/_sign-in.scss
+++ b/app/assets/stylesheets/_sign-in.scss
@@ -1,0 +1,117 @@
+//small center column layout. Should this go into UI Kit?
+//some visual defects with grid in chrome
+.sign-in {
+  @include outer-container;
+  @include span-columns(12 of 12);
+  @include link-colours($non-black, $light-aqua, $non-black);
+  @include button-colours($button-bg-colour, $button-bg-colour--hover, $button-bg-colour--active, $button-text-colour);
+  margin-top: 2 * $base-spacing;
+
+  @include media($tablet) {
+    @include span-columns(7 of 12);
+    @include shift(2.5 of 12);
+  }
+
+  @include media($desktop) {
+    @include span-columns(6 of 16);
+    @include shift(5 of 16);
+  }
+}
+
+.sign-in-form {
+  margin-top: 1.5 * $base-spacing;
+
+  //should we make all input labels bold?
+  label {
+    font-weight: 700;
+  }
+
+  //why isn't checkbox text same size as body?
+  form input[type="checkbox"] + label {
+    font-size: rem(16);
+    padding-left: 40px;
+
+    @include media($tablet) {
+      font-size: rem(17);
+    }
+
+  }
+
+  //formatting of form footer actions
+  .form-footer-actions {
+
+    input[type="submit"] {
+      margin-bottom: 0;
+      margin-top: $small-spacing;
+      width: 100%;
+    }
+
+    .form-options {
+      display: table;
+      table-layout: fixed;
+      width: 100%;
+
+      .remember-me {
+        display: block;
+
+        //Adjust alignment of checkbox
+        input[type="checkbox"] + label::before {
+          left: 0;
+          top: 11px;
+        }
+
+        input[type="checkbox"]:checked + label::after {
+          left: 5px;
+          top: 16px;
+        }
+
+        @include media($mobile) {
+
+          display: table-cell;
+          text-align: left;
+          width: 50%;
+
+          + p {
+            display: table-cell;
+            text-align: right;
+            width: 50%;
+          }
+        }
+      }
+    }
+  }
+
+  //formatting of form footer secondary links
+  .sign-in-footer-links {
+    text-align: center;
+
+    //should we have this defined globally?
+    .background-border-heading {
+      border-bottom: 1px solid $border-colour;
+      line-height: 1;
+      margin-bottom: $small-spacing;
+      margin-top: 0;
+      text-align: center;
+
+      span {
+        background-color: $white;
+        font-size: rem(20);
+        font-weight: $heading-font-weight;
+        padding: 0 $small-spacing;
+        position: relative;
+        top: 11px;
+      }
+    }
+
+    //should we have this defined globally?
+    .primary-link {
+      color: $aqua;
+      font-weight: $heading-font-weight;
+
+      &:hover,
+      &:focus {
+        color: $link-colour;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,5 +27,4 @@
  @import "times-dates-list"; //waiting for https://github.com/AusDTO/gov-au-ui-kit/pull/211 - will require html refactor
  @import "lists-ie-fix"; //github issue raised for these overrides with UI Kit https://github.com/AusDTO/gov-au-ui-kit/issues/258
  @import "tab-overrides"; //treb and Alz will address updating the styling of this in UI Kit
- @import "placeholder-link"; // https://github.com/AusDTO/gov-au-ui-kit/pull/279
  @import "sign-in";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,3 +27,5 @@
  @import "times-dates-list"; //waiting for https://github.com/AusDTO/gov-au-ui-kit/pull/211 - will require html refactor
  @import "lists-ie-fix"; //github issue raised for these overrides with UI Kit https://github.com/AusDTO/gov-au-ui-kit/issues/258
  @import "tab-overrides"; //treb and Alz will address updating the styling of this in UI Kit
+ @import "placeholder-link"; // https://github.com/AusDTO/gov-au-ui-kit/pull/279
+ @import "sign-in";

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -19,5 +19,3 @@
 
       - if controller_name != 'sessions'
         = link_to "Sign in", new_session_path(resource_name), :class => "primary-link"
-
-    / = render "devise/shared/links"

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,10 +1,23 @@
-%article.content-listing
-  %h2 Resend confirmation instructions
-  = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-    = f.error_notification
-    = f.full_error :confirmation_token
-    .form-inputs
-      = f.input :email, required: true, autofocus: true
-    .form-actions
-      = f.button :submit, "Resend confirmation instructions"
-  = render "devise/shared/links"
+%article.sign-in
+  %h1 Resend confirmation instructions
+  %section.sign-in-form
+    = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+      = f.error_notification
+      = f.full_error :confirmation_token
+      %p
+        = f.input :email, required: true, autofocus: true
+
+      .form-footer-actions
+        %p
+          = f.button :submit, "Resend confirmation instructions", role: 'button'
+
+    .sign-in-footer-links
+
+      %h2.background-border-heading
+        %span.inner
+          Or
+
+      - if controller_name != 'sessions'
+        = link_to "Sign in", new_session_path(resource_name), :class => "primary-link"
+
+    / = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,9 +1,25 @@
-%article.content-listing
-  %h2 Forgot your password?
-  = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-    = f.error_notification
-    .form-inputs
-      = f.input :email, required: true, autofocus: true
-    .form-actions
-      = f.button :submit, "Send me reset password instructions"
-  = render "devise/shared/links"
+%article.sign-in
+  %h1 Forgot your password?
+  %section.sign-in-form
+    = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+      = devise_error_messages!
+
+
+      %p
+        = f.input :email, required: true, autofocus: true
+      .form-footer-actions
+        %p
+          = f.button :submit, "Send me reset password instructions", role: 'button'
+
+    .sign-in-footer-links
+      - if devise_mapping.confirmable? && controller_name != 'confirmations'
+        = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+
+      %h2.background-border-heading
+        %span.inner
+          Or
+
+      - if controller_name != 'sessions'
+        = link_to "Sign in", new_session_path(resource_name), :class => "primary-link"
+
+    / = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -21,5 +21,3 @@
 
       - if controller_name != 'sessions'
         = link_to "Sign in", new_session_path(resource_name), :class => "primary-link"
-
-    / = render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -21,5 +21,3 @@
 
       - if controller_name != 'sessions'
         = link_to "I already have an account, Sign in", new_session_path(resource_name), :class => "primary-link"
-
-      / = render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,13 +1,25 @@
-%article.content-listing
-  %h2 Sign up
-  = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-    = f.error_notification
-    .form-inputs
+%article.sign-in
+  %h1 Sign up
+  %section.sign-in-form
+    = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+      = f.error_notification
+
+
+
       = f.input :email, required: true, autofocus: true
       = f.input :first_name, required: false
       = f.input :last_name, required: false
       = f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
       = f.input :password_confirmation, required: true
-    .form-actions
-      = f.button :submit, "Sign up", role: 'button'
-  = render "devise/shared/links"
+      .form-footer-actions
+        = f.button :submit, "Sign up", role: 'button'
+
+    .sign-in-footer-links
+      %h2.background-border-heading
+        %span.inner
+          Or
+
+      - if controller_name != 'sessions'
+        = link_to "I already have an account, Sign in", new_session_path(resource_name), :class => "primary-link"
+
+      / = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,16 +1,41 @@
-%article.content-listing
-  %h2 Log in
-  %section.form-wrapper
+%article.sign-in
+  %h1 Sign in &mdash; GOV.AU Author
+  %section.sign-in-form
     = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
       / TODO: UI Kit needs styles for email type (see https://github.com/AusDTO/gov-au-ui-kit/issues/51)
       /= f.input :email, autofocus: true
+
+      = devise_error_messages!
+
       %p
-        = f.label :email
+        = f.label :email, "Email address"
         = f.text_field :email
+
       %p
         = f.label :password
         = f.password_field :password
-      = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
-      = f.button :submit, "Log in", role: 'button'
 
-  = render "devise/shared/links"
+      .form-footer-actions
+        .form-options
+          .remember-me
+            = f.check_box :remember_me, as: :boolean if devise_mapping.rememberable?
+            %label.checkbox{ :for => "user_remember_me" } Remember me
+
+          %p
+            - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+              = link_to "Forgot password?", new_password_path(resource_name)
+
+        / = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
+        %p
+          = f.button :submit, "Sign in", role: 'button'
+
+    .sign-in-footer-links
+      - if devise_mapping.confirmable? && controller_name != 'confirmations'
+        = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+
+      %h2.background-border-heading
+        %span.inner
+          Or
+
+      - if devise_mapping.registerable? && controller_name != 'registrations'
+        = link_to "Sign up to be an author", new_registration_path(resource_name), :class => "primary-link"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,9 +2,6 @@
   %h1 Sign in
   %section.sign-in-form
     = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-      / TODO: UI Kit needs styles for email type (see https://github.com/AusDTO/gov-au-ui-kit/issues/51)
-      /= f.input :email, autofocus: true
-
       = devise_error_messages!
 
       %p
@@ -18,14 +15,14 @@
       .form-footer-actions
         .form-options
           .remember-me
-            = f.check_box :remember_me, as: :boolean if devise_mapping.rememberable?
-            %label.checkbox{ :for => "user_remember_me" } Remember me
+            if devise_mapping.rememberable?
+              = f.check_box :remember_me, as: :boolean if devise_mapping.rememberable?
+              %label.checkbox{ :for => "user_remember_me" } Remember me
 
           %p
             - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
               = link_to "Forgot password?", new_password_path(resource_name)
 
-        / = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
         %p
           = f.button :submit, "Sign in", role: 'button'
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 %article.sign-in
-  %h1 Sign in &mdash; GOV.AU Author
+  %h1 Sign in
   %section.sign-in-form
     = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
       / TODO: UI Kit needs styles for email type (see https://github.com/AusDTO/gov-au-ui-kit/issues/51)
@@ -38,4 +38,4 @@
           Or
 
       - if devise_mapping.registerable? && controller_name != 'registrations'
-        = link_to "Sign up to be an author", new_registration_path(resource_name), :class => "primary-link"
+        = link_to "Sign up", new_registration_path(resource_name), :class => "primary-link"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,6 +2,7 @@
   %h1 Sign in
   %section.sign-in-form
     = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+
       = devise_error_messages!
 
       %p
@@ -14,9 +15,9 @@
 
       .form-footer-actions
         .form-options
-          .remember-me
-            if devise_mapping.rememberable?
-              = f.check_box :remember_me, as: :boolean if devise_mapping.rememberable?
+          - if devise_mapping.rememberable?
+            .remember-me
+              = f.check_box :remember_me, as: :boolean
               %label.checkbox{ :for => "user_remember_me" } Remember me
 
           %p

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,5 +1,5 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
+  = link_to "Sign in", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
   = link_to "Sign up", new_registration_path(resource_name)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160812011645) do
+ActiveRecord::Schema.define(version: 20160826021046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,8 +22,9 @@ ActiveRecord::Schema.define(version: 20160812011645) do
     t.text     "summary"
     t.integer  "parent_id"
     t.integer  "children_count"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.boolean  "placeholder",    default: false, null: false
     t.index ["slug"], name: "index_categories_on_slug", using: :btree
   end
 

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe 'admin features', type: :feature do
         visit admin_root_path
         fill_in('Email', with: admin_user.email)
         fill_in('Password', with: admin_user.password)
-        click_button('Log in')
+        click_button('Sign in')
         expect(current_path).to eq(admin_root_path)
       end
     end
@@ -218,7 +218,7 @@ RSpec.describe 'admin features', type: :feature do
         visit admin_root_path
         fill_in('Email', with: non_admin_user.email)
         fill_in('Password', with: non_admin_user.password)
-        click_button('Log in')
+        click_button('Sign in')
         expect(current_path).to eq(editorial_root_path)
       end
     end


### PR DESCRIPTION
This PR fixes the current styling defects in the admin login interface by applying the current visual supplied from the designers. This PR closes SITES-601 and SITES-583.

I have run these changes by @klepas from UI Kit team and we will hold off bringing this component into UI Kit as they aren't ready to start looking at form templates quite yet. There is also a high chance this design may change when there is more design thinking applied to the editorial experience.

CSS is annotated to make refactoring this stuff out later as painfree as possible :)

Before:
![sign-in-old](https://cloud.githubusercontent.com/assets/12635736/17722731/cd547ae0-6477-11e6-85aa-95a5bf3ba5b9.png)

New:
![sign-in-new](https://cloud.githubusercontent.com/assets/12635736/17722746/ea40926a-6477-11e6-8296-63099190dc24.png)


