### PR TITLE
SITES-619 generate ETAGs in all show/index requests

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,6 @@
 class CategoriesController < ApplicationController
   def show
     @category = Category.friendly.find(params[:slug])
+    bustable_fresh_when(@category)
   end
 end

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -5,5 +5,6 @@ class DepartmentsController < ApplicationController
 
   def index
     @departments = Department.all.order(:name)
+    bustable_fresh_when(@departments)
   end
 end

--- a/app/controllers/editorial/editorial_controller.rb
+++ b/app/controllers/editorial/editorial_controller.rb
@@ -13,6 +13,7 @@ module Editorial
       authorize! :view, :editorial_page
       @sections = Section.all.order(:name).select{ |section| can? :read, section }
       @news_section = Section.find_by(name: 'news')
+      bustable_fresh_when([*@sections, @news_section])
     end
 
     class ClientParamError < StandardError

--- a/app/controllers/editorial/news_controller.rb
+++ b/app/controllers/editorial/news_controller.rb
@@ -6,6 +6,7 @@ module Editorial
 
     def index
       # TODO: return news editorial index
+      bustable_fresh_when(@sections)
     end
 
     def show
@@ -14,6 +15,7 @@ module Editorial
         slug: params[:slug]
       )
       authorize! :read, @article
+      bustable_fresh_when([*@sections, @article])
     end
 
     def new

--- a/app/controllers/editorial/nodes_controller.rb
+++ b/app/controllers/editorial/nodes_controller.rb
@@ -6,6 +6,7 @@ module Editorial
 
     before_action :derive_type, except: [:show, :prepare]
 
+
     def index
       #TODO: evaluate whether this is required anymore!
       unless params[:section_id].present?
@@ -14,6 +15,7 @@ module Editorial
       end
 
       @nodes = @section.nodes.order(updated_at: :desc).decorate
+      bustable_fresh_when([*@nodes, @section])
     end
 
     def show
@@ -24,6 +26,7 @@ module Editorial
         @news = NewsArticle.published_for_section(@section).limit(3)
       end
       set_menu_nodes
+      bustable_fresh_when([*@nodes, *@news, @section])
     end
 
     def prepare

--- a/app/controllers/editorial/requests_controller.rb
+++ b/app/controllers/editorial/requests_controller.rb
@@ -47,6 +47,7 @@ module Editorial
       @requestor = @rqst.user
       @approver = @rqst.approver.decorate unless @rqst.approver.nil?
       @owners = User.with_role(:owner, @rqst.section)
+      bustable_fresh_when([@rqst, @requestor, @approver, *@owners])
     end
 
     def update

--- a/app/controllers/editorial/sections_controller.rb
+++ b/app/controllers/editorial/sections_controller.rb
@@ -9,11 +9,14 @@ module Editorial
 
     def show
       @filter = %w(my_pages submissions).detect { |f| f == params[:filter] }
+      bustable_fresh_when(@section)  
     end
 
+    # TODO this should be a show/index on another resource.
     def collaborators
       @pending = Request.where(section: @section, state: :requested)
       @users = @section.users
+      bustable_fresh_when([*@pending, *@users])
     end
 
     protected

--- a/app/controllers/editorial/submissions_controller.rb
+++ b/app/controllers/editorial/submissions_controller.rb
@@ -16,6 +16,7 @@ module Editorial
       unless can? :review_in, @section
         @submissions = @submissions.for(current_user)
       end
+      bustable_fresh_when(@submissions)
     end
 
     def create

--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -5,6 +5,7 @@ class MinistersController < ApplicationController
   def index
     @ministers = Minister.order(:name)
     fudge_order
+    bustable_fresh_when(@ministers)
   end
 
   #TODO Get rid of this fudge once full requirements are clear

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -17,6 +17,7 @@ class NewsController < ApplicationController
     else
       @articles = news_articles
     end
+    bustable_fresh_when(@articles)
   end
 
 
@@ -29,7 +30,9 @@ class NewsController < ApplicationController
       section: @section
     )
     raise ActiveRecord::RecordNotFound unless can? :read_public, @node
-    render_node node
+    if bustable_stale?([@node, @section])
+      render_node node
+    end
   end
 
 

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -15,7 +15,9 @@ class NodesController < ApplicationController
     end
 
     set_menu_nodes
-    render_node node
+    if bustable_stale?([@node, @section, *@news, *@ministers, *@departments, *@agencies, *@categories])
+      render_node node
+    end
   end
 
   def home

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,48 @@
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+
+  controller do
+    def initialize(*args)
+      super
+      @some_data = Fabricate(:node)
+    end
+
+    def show 
+      if bustable_stale?(@some_data)
+        render :text => "Oh hi there!"
+      end
+    end
+  end
+
+  it "generates and respects ETAGs" do
+    get :show, :id => "ignored"
+    assert_response 200, @response.body
+    etag = @response.headers["ETag"]
+    @request.env["HTTP_IF_NONE_MATCH"] = etag
+    get :show, :id => "ignored"
+    assert_response 304, @response.body
+  end
+
+  describe "when a new version of the application is deployed" do
+
+    it "busts the ETAG" do
+      controller.stub(:etag_seed).and_return "CURRENT_SHA1"
+
+      get :show, :id => "ignored"
+      assert_response 200, @response.body
+      etag = @response.headers["ETag"]
+      @request.env["HTTP_IF_NONE_MATCH"] = etag
+      get :show, :id => "ignored"
+      assert_response 304, @response.body
+
+      # Deploy!
+      controller.stub(:etag_seed).and_return "NEW_SHA1"
+
+      @request.env["HTTP_IF_NONE_MATCH"] = etag
+      get :show, :id => "ignored"
+      assert_response 200, @response.body
+    end
+  end
+end


### PR DESCRIPTION
The generated ETAG is automatically busted when a new version of the app
is released.

NOTE: does not cover admin routes.