### PR TITLE
SITES-618 improve editorial index performance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  helper_method :decorated_current_user
 
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
@@ -14,7 +15,14 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user
-    super.try(:decorate)
+    user = super
+    if user
+      User.includes(:roles).find(user.id)
+    end
+  end
+
+  def decorated_current_user
+    current_user.try(:decorate)
   end
 
   protected

--- a/app/controllers/editorial/editorial_controller.rb
+++ b/app/controllers/editorial/editorial_controller.rb
@@ -11,7 +11,12 @@ module Editorial
 
     def index
       authorize! :view, :editorial_page
-      @sections = Section.all.order(:name).select{ |section| can? :read, section }
+      @sections = Section
+        .all
+        .includes(:home_node)
+        .order(:name)
+        .select{ |section| can? :read, section }
+
       @news_section = Section.find_by(name: 'news')
       bustable_fresh_when([*@sections, @news_section])
     end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -9,20 +9,8 @@ class UserDecorator < Draper::Decorator
     end
   end
 
-  def pending_request_for(section)
-    object.requests.find_by(section: section, state: 'requested')
-  end
 
-  def pending_request_for?(section)
-    pending_request_for(section).present?
-  end
-
-  # FIXME: Rollify uses polymophism which doesn't work properly
-  # with STI on Section. Suggest using a collaborator model on sections instead
-  def collaborator_on?(section)
-    object.roles.exists?(resource_id: section)
-  end
-
+  # TODO: this belongs on User. It's not a presentation concern.
   def roles_for(section)
     roles = []
     Section.find_roles.pluck(:name).uniq.each do |role|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,7 +4,11 @@ class Ability
   def initialize(user)
     user ||= User.new # guest user (not logged in)
 
-    if user.has_role? :admin
+    # NOTE: never call `User#has_role?`. Always use `User#has_cached_role?`
+    # This avoids a database hit per role check. However, it relied on the
+    # fact that `ApplicationController#current_user` preloads the roles.
+
+    if user.has_cached_role? :admin
       can :manage, :all
 
       cannot :manage, Node do |node|
@@ -21,28 +25,28 @@ class Ability
       can :view, :editorial_page
 
       can :manage, Node do |node|
-        user.has_role?(:author, node.section) &&
+        user.has_cached_role?(:author, node.section) &&
             node.section.cms_type == Section::COLLABORATE_CMS
       end
 
       can :show, Request do |request|
         user == request.user ||
-            user.has_role?(:owner, request.section)
+            user.has_cached_role?(:owner, request.section)
       end
 
       can :update, Request do |request|
         request.state == 'requested' &&
-            user.has_role?(:owner, request.section) &&
+            user.has_cached_role?(:owner, request.section) &&
             user != request.user
       end
 
       can :read, Node do |node|
-        user.has_role?(:reviewer, node.section) ||
-            user.has_role?(:owner, node.section)
+        user.has_cached_role?(:reviewer, node.section) ||
+            user.has_cached_role?(:owner, node.section)
       end
 
       can :create_in, Section do |section|
-        user.has_role?(:author, section) &&
+        user.has_cached_role?(:author, section) &&
             section.cms_type == Section::COLLABORATE_CMS
       end
 
@@ -53,19 +57,19 @@ class Ability
 
       can :read, Section do |section|
         (
-          user.has_role?(:author, section)   ||
-          user.has_role?(:reviewer, section) ||
-          user.has_role?(:owner, section)
+          user.has_cached_role?(:author, section)   ||
+          user.has_cached_role?(:reviewer, section) ||
+          user.has_cached_role?(:owner, section)
         ) && section.cms_type == Section::COLLABORATE_CMS
       end
 
       can :review, Submission do |submission|
         submission.submitted? && submission.section.present? &&
-          user.has_role?(:reviewer, submission.section)
+          user.has_cached_role?(:reviewer, submission.section)
       end
 
       can :review_in, Section do |section|
-        user.has_role? :reviewer, section
+        user.has_cached_role? :reviewer, section
       end
     end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -7,6 +7,7 @@ class Section < ApplicationRecord
   has_many :news_distributions, as: :distribution
   has_many :news_articles, through: :news_distributions
   has_and_belongs_to_many :categories, join_table: :section_categories
+  has_one :home_node, class_name: 'SectionHome'
 
   has_and_belongs_to_many :sections,
       class_name: 'Section',
@@ -25,24 +26,10 @@ class Section < ApplicationRecord
 
   # Finds the users with a role on this Section
   def users
+    # TODO there has to be a one hit way to get these results
     Section.find_roles.pluck(:name).inject(Array.new) do |result, role|
       result += User.with_role(role, self)
     end.uniq
-  end
-
-  def home_node
-    nodes.with_sectionless_parent.first
-  end
-
-  # we can't use delegate :name, to home_node because we have to create the Section before the SectionHome
-  # we can't have the SectionHome delegate :name to the section because that doesn't work with the revisable system
-  # So manually override name to delegate to the home_node if it exists
-  def name
-    if home_node
-      home_node.name
-    else
-      super
-    end
   end
 
   def news_node

--- a/app/models/section_home.rb
+++ b/app/models/section_home.rb
@@ -3,7 +3,15 @@ class SectionHome < Node
   validates :parent, ancestry_depth: { equals: 1 }
   validates :section, presence: true, uniqueness: true
 
+  after_save :propagate_name_to_section, only: :name_changed?
+
   def layout
     'section_home'
+  end
+
+  private
+
+  def propagate_name_to_section
+    section.update_attribute('name', self.name)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,9 @@ class User < ApplicationRecord
   rolify
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :validatable, :confirmable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable,
+         :validatable, :confirmable
 
   has_many :requests
 
@@ -23,5 +25,19 @@ class User < ApplicationRecord
 
   def is_member?(section)
     member_of_sections.include? section
+  end
+
+  def pending_request_for(section)
+    requests.find_by(section: section, state: 'requested')
+  end
+
+  def pending_request_for?(section)
+    pending_request_for(section).present?
+  end
+
+  # FIXME: Rollify uses polymophism which doesn't work properly
+  # with STI on Section. Suggest using a collaborator model on sections instead
+  def collaborator_on?(section)
+    roles.exists?(resource_id: section)
   end
 end

--- a/app/views/application/_signed_in_nav.html.haml
+++ b/app/views/application/_signed_in_nav.html.haml
@@ -13,7 +13,7 @@
       %ul.inline-links--inverted
         %li
           %i.fa-user.fa
-          = current_user.display_name
+          = decorated_current_user.display_name
         %li= link_to('Sign out', destroy_user_session_path, method: :delete)
 
 

--- a/spec/models/section_home_spec.rb
+++ b/spec/models/section_home_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe SectionHome, type: :model do
     it { is_expected.not_to be_valid }
   end
 
+  describe 'name' do
+    let!(:section)      { Fabricate(:section, name: "FOO") }
+    let!(:section_home) { Fabricate(:section_home, section: section, name: "FOO") }
+
+    it 'updates section name when name is changed' do
+      expect(section.name).to eql("FOO")
+      section_home.name = "BAR"
+      section_home.save!
+      section.reload
+      expect(section.name).to eql("BAR")
+    end
+  end
 end


### PR DESCRIPTION
- Loading the Section now preloads the home_node for the Section
- ApplicationController#current_user now preloads all of the User roles

Also added a feature to ensure that Section#name is updated when
SectionHome#name is updated. Ideally we can restore the delegate at some
point but Sections are created *before* the SectionHome in the admin
area and they will need to display a name in the meantime.

Fixed related breakages.