### PR TITLE
SITES-602 Bugfix/node fabricator

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ApplicationController, type: :controller do
   controller do
     def initialize(*args)
       super
-      @some_data = Fabricate(:node)
+      @some_data = Fabricate(:general_content)
     end
 
     def show

--- a/spec/fabricators/node.rb
+++ b/spec/fabricators/node.rb
@@ -1,5 +1,5 @@
-# FIXME: rename this node_defaults to prevent instantiation
-Fabricator(:node) do
+# You should not fabricate the base node
+Fabricator(:abstract_node, class_name: :node) do
   name { Fabricate.sequence(:node_name) { |i| "node-#{i}" } }
   state 'published'
   short_summary 'A single sentence'
@@ -21,11 +21,11 @@ Fabricator(:node) do
   end
 end
 
-Fabricator(:general_content, from: :node, class_name: :general_content) do
+Fabricator(:general_content, from: :abstract_node, class_name: :general_content) do
   name { Fabricate.sequence(:general_content_name) { |i| "general_content-#{i}" } }
 end
 
-Fabricator(:news_article, from: :node, class_name: :news_article) do
+Fabricator(:news_article, from: :abstract_node, class_name: :news_article) do
   name { Fabricate.sequence(:news_name) { |i| "news-#{i}" } }
   short_summary 'foo'
   release_date Date.today
@@ -37,7 +37,7 @@ Fabricator(:root_node, class_name: :root_node) do
   content_body 'Welcome to gov.au'
 end
 
-Fabricator(:section_home, class_name: :section_home, from: :node) do
+Fabricator(:section_home, class_name: :section_home, from: :abstract_node) do
   parent do |attrs|
     if Node.root_node.present?
       Node.root_node
@@ -58,7 +58,7 @@ Fabricator(:section_home, class_name: :section_home, from: :node) do
   end
 end
 
-Fabricator(:custom_template_node, class_name: :custom_template_node, from: :node) do
+Fabricator(:custom_template_node, class_name: :custom_template_node, from: :abstract_node) do
   name { Fabricate.sequence(:custom_template_node_name) { |i| "custom-template-node-#{i}" } }
   template 'custom/public_holidays_tas'
 end


### PR DESCRIPTION
Fixing one wrong instantiation of :node in a test, and renamed node fabricator to `abstract_node`