### PR TITLE
Add closing </nav> tag

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,7 +22,7 @@
  @import "ie";
 
  //all of the below sass will need to be removed once it is added to UI Kit
- @import "callout-basic"; // not yet added to UI Kit - this callout exists on the QLD daylight saving page
+ @import "callout-basic"; // GitHub issue raised for this https://github.com/AusDTO/gov-au-ui-kit/issues/301
  @import "daylight-savings-callout"; // https://github.com/AusDTO/gov-au-ui-kit/pull/209 changing callout--icon-left to callout--reminder
  @import "times-dates-list"; //waiting for https://github.com/AusDTO/gov-au-ui-kit/pull/211 - will require html refactor
  @import "lists-ie-fix"; //github issue raised for these overrides with UI Kit https://github.com/AusDTO/gov-au-ui-kit/issues/258

--- a/app/views/templates/custom/daylight_savings_nt.html.erb
+++ b/app/views/templates/custom/daylight_savings_nt.html.erb
@@ -16,7 +16,7 @@
 <li><a href="/times-and-dates/australian-daylight-saving/northern-territory" class="is-current"><span class="is-visuallyhidden">View by </span>NT</a></li>
 <li><a href="/times-and-dates/australian-daylight-saving/australian-capital-territory"><span class="is-visuallyhidden">View by </span>ACT</a></li>
 </ul>
-</div>
+</nav>
 
 <div class="callout--calendar-event">
   <span class="event-name">Northern Territory does not observe daylight saving.</span>
@@ -86,7 +86,7 @@
       <p>Currently in Australian Eastern Standard Time (AEST) <span>Half an hour ahead of Northern Territory</span></p>
     </article>
   </li>
-  
+
   <li>
     <article>
       <h4>


### PR DESCRIPTION
This PR fixes the broken layout on the Norther Territory daylight savings page caused by an open <nav> tag.