### PR TITLE
Enable best-practice accessibility tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file is influenced by http://keepachangelog.com/.
 - Fixed leaking email addresses on password reset and resend email confirmation pages
 - Remove instances of permit! mass assignment
 
+- Improved accessibility
 
 ## [v1.1.0] - 2016-08-23
 ### Added

--- a/app/assets/stylesheets/_content.scss
+++ b/app/assets/stylesheets/_content.scss
@@ -1,0 +1,3 @@
+#content:focus {
+  outline: none;
+}

--- a/app/assets/stylesheets/_news-listing.scss
+++ b/app/assets/stylesheets/_news-listing.scss
@@ -1,0 +1,7 @@
+.news-listing {
+  @extend .list-horizontal;
+
+  h2 {
+    @extend h3
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,8 @@
  @import "lists-ie-fix"; //github issue raised for these overrides with UI Kit https://github.com/AusDTO/gov-au-ui-kit/issues/258
  @import "tab-overrides"; //treb and Alz will address updating the styling of this in UI Kit
  @import "sign-in";
+
+ // These have questions raised on ui-kit for whether they want to include it or if it should
+ // be our custom stuff
+ @import "news-listing"; // https://github.com/AusDTO/gov-au-ui-kit/issues/299
+ @import "content"; // https://github.com/AusDTO/gov-au-ui-kit/issues/300

--- a/app/views/departments/index.html.haml
+++ b/app/views/departments/index.html.haml
@@ -10,7 +10,7 @@
         Departments
 
 
-%article.content-listing
+%article.content-listing#content{tabindex: -1}
   %ul.list-highlighted
     - departments.each do |department|
       %li

--- a/app/views/feedback/new.html.haml
+++ b/app/views/feedback/new.html.haml
@@ -1,5 +1,5 @@
 
-%section#content.content-main.form_wrapper{role: "main"}
+%section#content.content-main.form_wrapper{role: "main", tabindex: -1}
   %h1 Your feedback
   = simple_form_for(@form, url: feedback_path) do |f|
     = f.input :comment, as: :text

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -53,17 +53,17 @@
           %nav
             %ul
               %li
-                %a{href: 'javascript:void(0)'} About
+                %span.placeholder-link About
               %li
-                %a{href: 'javascript:void(0)'} Accessibility
+                %span.placeholder-link Accessibility
               %li
-                %a{href: 'javascript:void(0)'} Copyright
+                %span.placeholder-link Copyright
               %li
-                %a{href: 'javascript:void(0)'} Help
+                %span.placeholder-link Help
               %li
-                %a{href: 'javascript:void(0)'} Site map
+                %span.placeholder-link Site map
               %li
-                %a{href: 'javascript:void(0)'} Terms of use
+                %span.placeholder-link Terms of use
           %p
             &copy; Commonwealth of Australia
             %br

--- a/app/views/layouts/news_article.html.haml
+++ b/app/views/layouts/news_article.html.haml
@@ -1,5 +1,5 @@
 = inside_layout :application do
-  %article#content{class: "content-main", role: "main"}
+  %article#content{class: "content-main", role: "main", tabindex: -1}
     = yield
 
   = content_for :title do

--- a/app/views/layouts/section.html.haml
+++ b/app/views/layouts/section.html.haml
@@ -1,5 +1,5 @@
 = inside_layout :application do
-  %article#content{class: "content-main", role: "main"}
+  %article#content{class: "content-main", role: "main", tabindex: -1}
     = yield
 
   = content_for :after_header do

--- a/app/views/layouts/section_home.html.haml
+++ b/app/views/layouts/section_home.html.haml
@@ -1,5 +1,5 @@
 = inside_layout :application do
-  %article#content{class: "content-main", role: "main"}
+  %article#content{class: "content-main", role: "main", tabindex: -1}
     = yield
 
   = content_for :after_header do

--- a/app/views/ministers/index.html.haml
+++ b/app/views/ministers/index.html.haml
@@ -9,7 +9,7 @@
       %h1
         Cabinet Ministers
 
-%article.content-listing
+%article.content-listing#content{tabindex: -1}
   %ul.list-highlighted
     - ministers.each do |minister|
       %li

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -24,17 +24,17 @@
         %p
           Announcements, media releases, interviews, speeches and more from the Australian Government.
 
-%article#content{class: "#{news_article_class}"}
+%article#content{class: "#{news_article_class}", tabindex: -1}
   -# H1 not included in the hero bar for section news lists so include it here
   -# TODO: include a tagline/abstract once we know what it should be
   -# (may be section specific)
   - if @section
     %h1 News
-  %ul.list-horizontal
+  %ul.news-listing
     - articles.each do |article|
       %li
         %article
-          %h3= link_to article.name, public_node_path(article)
+          %h2= link_to article.name, public_node_path(article)
           %div.meta
             %time{ datetime: "#{article.release_date}" } #{l(article.release_date, format: :news)}
             = link_to article.section.name, public_node_path(article.section.home_node), { rel: :author }

--- a/app/views/templates/root_node.html.haml
+++ b/app/views/templates/root_node.html.haml
@@ -1,6 +1,6 @@
 - breadcrumb :public_node, node
 
-%article.content-listing
+%article.content-listing#content{tabindex: -1}
   %section.home-category-list
     %h2 What is GOV.AU Beta?
     .abstract

--- a/lib/tasks/ui-kit.rake
+++ b/lib/tasks/ui-kit.rake
@@ -2,11 +2,11 @@ require 'net/http'
 require 'zip'
 
 namespace :ui_kit do
-  desc 'Sets up UI kit with updates'
+  desc 'Sets up UI kit with updates. To download from a custom url (eg circleci), define UI_KIT_URL.'
 
   task :update do
     def download_asset(name, destination)
-      ui_kit_url = "http://gov-au-ui-kit.apps.staging.digital.gov.au/latest/"
+      ui_kit_url = ENV['UI_KIT_URL'] || "http://gov-au-ui-kit.apps.staging.digital.gov.au/latest/"
       path_to_file = "vendor/assets/"+destination
       File.delete(path_to_file) if File.exist?(path_to_file)
       file = File.new path_to_file, 'wb+'

--- a/spec/fabricators/node.rb
+++ b/spec/fabricators/node.rb
@@ -19,6 +19,18 @@ Fabricator(:abstract_node, class_name: :node) do
       attrs[:parent].section
     end
   end
+
+  transient :placeholder
+
+  after_build do |node, transients|
+    if transients[:placeholder]
+      # Note: options must be set as a whole (ie `node.options.placeholder = true` does not work)
+      o = node.options
+      o.placeholder = true
+      node.options = o
+    end
+  end
+
 end
 
 Fabricator(:general_content, from: :abstract_node, class_name: :general_content) do

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe 'accessibility:', :js, :truncate, :nodes_helper, type: :feature d
       end
       visit url
       expect(page.status_code).to eq(200)
-      # TODO: Remove skip clause once ui-kit colours are updated
-      # See https://github.com/AusDTO/gov-au-ui-kit/issues/271
-      expect(page).to be_accessible.according_to(:wcag2a, :wcag2aa).skipping('color-contrast')
+      # list of rules: https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md
+      expect(page).to be_accessible.according_to(:wcag2a, :wcag2aa, 'best-practice').skipping('region')
+      # There are currently issues with the region tests failing on the HTML tag, so we only test that within the body
+      # https://github.com/dequelabs/axe-core/issues/215
+      expect(page).to be_accessible.within('body').checking_only('region')
     end
   end
 
@@ -58,12 +60,14 @@ RSpec.describe 'accessibility:', :js, :truncate, :nodes_helper, type: :feature d
     let!(:topic_home) { Fabricate(:section_home, section: topic) }
     let!(:news_article) { Fabricate(:news_article, parent: department_home, sections: [department, minister]) }
     let!(:general_content) { Fabricate(:general_content, parent: department_home) }
+    let!(:placeholder_content) { Fabricate(:general_content, parent: department_home, placeholder: true) }
 
     include_examples 'is accessible', 'root_path', true
     include_examples 'is accessible', 'departments_path', true
     include_examples 'is accessible', 'ministers_path', true
     include_examples 'is accessible', 'new_feedback_path', true
     include_examples 'is accessible', 'news_articles_path', true
+    include_examples 'is accessible', 'section_news_articles_path(department.slug)', true
     include_examples 'is accessible', 'public_node_path(news_article)', true
     include_examples 'is accessible', 'public_node_path(department.home_node)', true
     include_examples 'is accessible', 'public_node_path(minister.home_node)', true


### PR DESCRIPTION
This needs the next release of ui-kit to pass the colour contrast tests (this branch has their latest develop). But review comments are welcome now.

Includes:
* re-adding the `tabindex="-1"` attribute to the target of the skip link. Axe-core thinks it's not a valid skip link without it and it's easy enough to disable the focus outline.
* Updating the news list page to use `<h2>` and fixing the CSS so they look like `<h3>`