### PR TITLE
[SITES-639] Enable devise paranoia mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This file is influenced by http://keepachangelog.com/.
 
 ### Fixed
 
+- Fixed leaking email addresses on password reset and resend email confirmation pages
+
 
 ## [v1.1.0] - 2016-08-23
 ### Added

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -76,7 +76,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/spec/features/enumerating_emails_spec.rb
+++ b/spec/features/enumerating_emails_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'cannot enumerate emails', type: :feature do
+
+  Warden.test_mode!
+
+  let!(:root_node) { Fabricate(:root_node) }
+  let(:fake_email) { 'not-a-real-email@gov.au' }
+  let!(:user) { Fabricate(:user) }
+
+  it 'on password reset form' do
+    visit new_user_password_path
+    fill_in('Email', with: user.email)
+    click_button('Send')
+    expect(current_path).to eq(new_user_session_path)
+    flash1 = page.find('.callout').text
+    visit new_user_password_path
+    fill_in('Email', with: fake_email)
+    click_button('Send')
+    expect(current_path).to eq(new_user_session_path)
+    flash2 = page.find('.callout').text
+    expect(flash1).to eq(flash2)
+  end
+
+  it 'on email confirmation form' do
+    visit user_confirmation_path
+    fill_in('Email', with: user.email)
+    click_button('Resend')
+    expect(current_path).to eq(new_user_session_path)
+    flash1 = page.find('.callout').text
+    visit user_confirmation_path
+    fill_in('Email', with: fake_email)
+    click_button('Resend')
+    expect(current_path).to eq(new_user_session_path)
+    flash2 = page.find('.callout').text
+    expect(flash1).to eq(flash2)
+  end
+
+  it 'on sign up form' do
+    # TODO
+  end
+
+  it 'on sign in form' do
+    visit new_user_session_path
+    fill_in('Email', with: user.email)
+    fill_in('Password', with: 'foo')
+    click_button('Sign in')
+    flash1 = page.find('.callout').text
+    fill_in('Email', with: fake_email)
+    fill_in('Password', with: 'foo')
+    click_button('Sign in')
+    flash2 = page.find('.callout').text
+    expect(flash1).to eq(flash2)
+  end
+end


### PR DESCRIPTION
This stops enumerating email addresses for everything except sign-up. Sign up requires more thought so I figured I'd put up the easy part first.

Note: It's currently using the default devise flash messages. If people have suggestions for better language, I'm all ears.

![image](https://cloud.githubusercontent.com/assets/4583474/17918145/d21a83ec-6a05-11e6-81be-a26d566cf723.png)
![image](https://cloud.githubusercontent.com/assets/4583474/17918148/d5ffadc0-6a05-11e6-9382-c04456b8a1b3.png)

![image](https://cloud.githubusercontent.com/assets/4583474/17918191/3f3c816e-6a06-11e6-8eb6-24231ae76c9e.png)
![image](https://cloud.githubusercontent.com/assets/4583474/17918194/421bb954-6a06-11e6-814d-bb58e45fe275.png)
