### PR TITLE
SITES-627 Render placeholder links as placeholder-link spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is influenced by http://keepachangelog.com/.
 - Verification of identity when accessing protected pages
 - Phone number verification when changing numbers
 - Simple feedback system and admin
+- Rendering # links as placeholder spans
 
 ### Changed
 - Upgrade Rails to v5.0.0.1

--- a/app/renderers/content_markdown.rb
+++ b/app/renderers/content_markdown.rb
@@ -1,5 +1,6 @@
 # for more details, see https://github.com/vmg/redcarpet
 class ContentMarkdown < Redcarpet::Render::HTML
+  include ActionView::Helpers::TagHelper
 
   def initialize(extensions = {})
     super(extensions.merge(with_toc_data: true))
@@ -11,4 +12,13 @@ class ContentMarkdown < Redcarpet::Render::HTML
     "<table class=\"content-table\"><thead>\n#{header}</thead><tbody>\n#{body}</tbody></table>\n"
   end
 
+  # override the link method to replace # links with placeholder-link spans
+  # super: https://github.com/vmg/redcarpet/blob/master/ext/redcarpet/html.c#L327
+  def link(link, title, content)
+    if link == "#"
+      content_tag(:span, content, {:class => "placeholder-link", :title => title})
+    else
+      content_tag(:a, content, {:href => link, :title => title})
+    end
+  end
 end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -20,6 +20,23 @@ RSpec.describe MarkdownHelper do
       it { is_expected.to have_css('table.content-table') }
     end
 
+    context 'renders links' do
+      subject { markdown_content('[a link](http://example.com)') }
+      it { is_expected.to have_link('a link', href: 'http://example.com') }
+    end
+
+    context 'renders links without xss' do
+      subject { markdown_content('[<script>alert("Foo")</script>](http://example.com)') }
+      it { is_expected.not_to have_css('script') }
+    end
+
+    context 'changes # links to placeholder span' do
+      subject { markdown_content('[a placeholder link](#)') }
+      it { is_expected.not_to have_link('a placeholder link', href: '#') }
+      it { is_expected.to have_css('span.placeholder-link') }
+      it { is_expected.to match('a placeholder link') }
+    end
+
     context 'strips script tags' do
       subject { markdown_content('Stuff<script>alert()</script>') }
       it { is_expected.to match('Stuff') }
@@ -32,9 +49,9 @@ RSpec.describe MarkdownHelper do
     end
 
     context 'handles tel: telephone links' do
-      subject { markdown_content('<a href="tel:133 677">National Relay Service - TTY/voice calls</a>')}
-      it {is_expected.to have_link('National Relay Service - TTY/voice calls',
-                                   :href => "tel:133%20677")}
+      subject { markdown_content('<a href="tel:133 677">National Relay Service - TTY/voice calls</a>') }
+      it { is_expected.to have_link('National Relay Service - TTY/voice calls',
+                                    :href => "tel:133%20677") }
     end
 
     context 'creates toc data' do


### PR DESCRIPTION
Change placeholder links to [placeholder-link spans](http://gov-au-ui-kit.apps.staging.digital.gov.au/section-link-styles.html#guide-link-styles-3-placeholder-links) as requested in #415.
Have only implemented for the public markdown renderer, so it won't happen in the editor client-side preview. Am tempted to change to a regex approach, but it was simpler this way re-using code from the spike. And I didn't want [to add another problem](http://regex.info/blog/2006-09-15/247). Thoughts?