### PR TITLE
[SITES-649] fix admins bypassing 2fa on setup using admin_root_path

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,6 +6,8 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
+    include ::IncompleteTfaSetup
+
     before_action ->() { authorize! :manage, :all }
     before_action :complete_two_factor_setup
 
@@ -19,23 +21,6 @@ module Admin
       respond_to do |format|
         format.html { redirect_to new_user_session_path, :alert => exception.message }
         format.json { render status: :unauthorized, json: { message: exception.message } }
-      end
-    end
-
-
-    #TODO: eventually move this into a Warden after_authentication method
-    def complete_two_factor_setup
-      whitelist = [
-          destroy_user_session_path
-      ]
-
-      if current_user && !current_user.account_verified && current_user.confirmed_at
-        # Users need to be able to verify their tfa code
-        unless request.path.start_with?(users_two_factor_setup_path) ||
-            whitelist.include?(request.path)
-
-          redirect_to new_users_two_factor_setup_path
-        end
       end
     end
   end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -7,6 +7,7 @@
 module Admin
   class ApplicationController < Administrate::ApplicationController
     before_action ->() { authorize! :manage, :all }
+    before_action :complete_two_factor_setup
 
     # Override this value to specify the number of elements to display at a time
     # on index pages. Defaults to 20.
@@ -18,6 +19,23 @@ module Admin
       respond_to do |format|
         format.html { redirect_to new_user_session_path, :alert => exception.message }
         format.json { render status: :unauthorized, json: { message: exception.message } }
+      end
+    end
+
+
+    #TODO: eventually move this into a Warden after_authentication method
+    def complete_two_factor_setup
+      whitelist = [
+          destroy_user_session_path
+      ]
+
+      if current_user && !current_user.account_verified && current_user.confirmed_at
+        # Users need to be able to verify their tfa code
+        unless request.path.start_with?(users_two_factor_setup_path) ||
+            whitelist.include?(request.path)
+
+          redirect_to new_users_two_factor_setup_path
+        end
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,8 +28,7 @@ class ApplicationController < ActionController::Base
     current_user.try(:decorate)
   end
 
-  #TODO: move this into a Warden after_authentication method
-  # This seems like a stop-gap but works technically
+  #TODO: eventually move this into a Warden after_authentication method
   def complete_two_factor_setup
     whitelist = [
       destroy_user_session_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 require 'digest/sha1'
 
 class ApplicationController < ActionController::Base
+  include IncompleteTfaSetup
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
@@ -28,21 +29,6 @@ class ApplicationController < ActionController::Base
     current_user.try(:decorate)
   end
 
-  #TODO: eventually move this into a Warden after_authentication method
-  def complete_two_factor_setup
-    whitelist = [
-      destroy_user_session_path
-    ]
-
-    if current_user && !current_user.account_verified && current_user.confirmed_at
-      # Users need to be able to verify their tfa code
-      unless request.path.start_with?(users_two_factor_setup_path) ||
-        whitelist.include?(request.path)
-
-        redirect_to new_users_two_factor_setup_path
-      end
-    end
-  end
 
   protected
   def confirm_two_factor!

--- a/app/controllers/concerns/incomplete_tfa_setup.rb
+++ b/app/controllers/concerns/incomplete_tfa_setup.rb
@@ -1,0 +1,19 @@
+module IncompleteTfaSetup
+  extend ActiveSupport::Concern
+
+  #TODO: eventually move this into a Warden after_authentication method
+  def complete_two_factor_setup
+    whitelist = [
+        destroy_user_session_path
+    ]
+
+    if current_user && !current_user.account_verified && current_user.confirmed_at
+      # Users need to be able to verify their tfa code
+      unless request.path.start_with?(users_two_factor_setup_path) ||
+          whitelist.include?(request.path)
+
+        redirect_to new_users_two_factor_setup_path
+      end
+    end
+  end
+end

--- a/spec/features/signing_in_2fa_spec.rb
+++ b/spec/features/signing_in_2fa_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe 'signing in 2fa', type: :feature do
         to_return(:status => 200, :body => "", :headers => {})
   }
 
+
+  describe 'two factor authentication as admin' do
+    let!(:admin) { Fabricate(:user, is_admin: true, bypass_tfa: false) }
+
+    context 'when logging in' do
+      before{
+        login_as(admin)
+        visit admin_root_path
+      }
+
+
+      it 'should force user to do 2fa' do
+        expect(page).to have_content('Enter the code that was sent to you')
+        expect(page).to have_field('Enter 6 digit code')
+      end
+    end
+
+  end
+
+
   describe 'two factor authentication as otp user' do
     before {
       login_as(otp_user)


### PR DESCRIPTION
Admin users setting up 2FA for the first time can no longer bypass this by going directly to the (default redirect) /admin route.