### PR TITLE
[WIP] SITES-632 Create RootSection to allow authors to create root level pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is influenced by http://keepachangelog.com/.
 - Phone number verification when changing numbers
 - Simple feedback system and admin
 - Rendering # links as placeholder spans
+- Root level pages able to be created 
 
 ### Changed
 - Upgrade Rails to v5.0.0.1

--- a/app/controllers/admin/root_sections_controller.rb
+++ b/app/controllers/admin/root_sections_controller.rb
@@ -1,0 +1,23 @@
+module Admin
+class TopicsController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # simply overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Topic.all.paginate(10, params[:page])
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Topic.find_by!(slug: param)
+    # end
+
+    # See https://administrate-docs.herokuapp.com/customizing_controller_actions
+    # for more information
+
+    def find_resource(param)
+      RootSection.find param
+    end
+  end
+end

--- a/app/dashboards/root_section_dashboard.rb
+++ b/app/dashboards/root_section_dashboard.rb
@@ -1,0 +1,8 @@
+require "administrate/base_dashboard"
+
+class RootSectionDashboard < SectionDashboard
+
+  def show_in_sidebar?
+    true
+  end
+end

--- a/app/models/general_content.rb
+++ b/app/models/general_content.rb
@@ -3,7 +3,11 @@ class GeneralContent < Node
 
   validates_with SectionHeritageValidator
   validates_presence_of :section
-  validates :parent, ancestry_depth: { minimum: 2 }
+  validates :parent, ancestry_depth: { minimum: 2 }, if: :not_root_page?
+
+  def not_root_page?
+    not section.is_a? RootSection
+  end
 
   def available_options
     super.merge({toc: 0})

--- a/app/models/root_node.rb
+++ b/app/models/root_node.rb
@@ -1,7 +1,16 @@
 class RootNode < Node
-  validates_absence_of :parent, :slug, :section
+  validates_absence_of :parent, :slug
+  before_create :associate_root_section
 
   def layout
     'root'
+  end
+
+  def associate_root_section
+    #create a root section if not created
+    if not RootSection.first
+      RootSection.new.save()
+    end
+    self.section_id = RootSection.first.id
   end
 end

--- a/app/models/root_node.rb
+++ b/app/models/root_node.rb
@@ -7,10 +7,12 @@ class RootNode < Node
   end
 
   def associate_root_section
-    #create a root section if not created
-    if not RootSection.first
-      RootSection.new.save()
+    if not self.section_id
+      #create a root section if not created
+      if not RootSection.first
+        RootSection.new.save()
+      end
+      self.section_id = RootSection.first.id
     end
-    self.section_id = RootSection.first.id
   end
 end

--- a/app/models/root_section.rb
+++ b/app/models/root_section.rb
@@ -2,10 +2,6 @@ class RootSection < Section
 resourcify
 
 def generate_home_node
-  unless Rails.env.test?  # <-- added this to avoid breaking specs
-    unless home_node.present?
-      home_node = Node.root_node
-    end
-  end
+  # no home_node needed
 end
 end

--- a/app/models/root_section.rb
+++ b/app/models/root_section.rb
@@ -1,0 +1,11 @@
+class RootSection < Section
+resourcify
+
+def generate_home_node
+  unless Rails.env.test?  # <-- added this to avoid breaking specs
+    unless home_node.present?
+      home_node = Node.root_node
+    end
+  end
+end
+end

--- a/app/models/root_section.rb
+++ b/app/models/root_section.rb
@@ -1,7 +1,14 @@
 class RootSection < Section
 resourcify
 
+after_initialize :assign_defaults, if: 'new_record?'
+
 def generate_home_node
   # no home_node needed
+end
+
+private
+def assign_defaults
+  self.name = "Root level pages"
 end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -70,6 +70,6 @@ class Section < ApplicationRecord
   end
 end
 
-%w(agency department minister topic).each do |clazz_file|
+%w(agency department minister root_section topic).each do |clazz_file|
   require_dependency clazz_file
 end

--- a/app/views/application/_signed_in_nav.html.haml
+++ b/app/views/application/_signed_in_nav.html.haml
@@ -4,7 +4,7 @@
       %nav.controls
         %p.inline-links--inverted
           = link_to('Editorial', editorial_root_path)
-          - if @section
+          - if @section and not @section.is_a? RootSection
             %b  /
             = link_to @section.name, editorial_section_path(@section)
         = yield :toolbar_actions

--- a/app/views/layouts/news_article.html.haml
+++ b/app/views/layouts/news_article.html.haml
@@ -6,10 +6,11 @@
     = @node.name
 
   = content_for :after_header do
-    %div{class: "hero-sml #{hero_class(@section)}"}
-      .wrapper
-        %p
-          = @section.name
+    - unless @section.is_a? RootSection
+      %div{class: "hero-sml #{hero_class(@section)}"}
+        .wrapper
+          %p
+            = @section.name
 
   = content_for :toolbar_actions do
     = render partial: 'application/page_actions', locals: {section: @section, node: @node}

--- a/app/views/layouts/section.html.haml
+++ b/app/views/layouts/section.html.haml
@@ -3,10 +3,11 @@
     = yield
 
   = content_for :after_header do
-    %div{class: "hero-sml #{hero_class(@section)}"}
-      .wrapper
-        %p
-          = @section.name
+    - unless @section.is_a? RootSection
+      %div{class: "hero-sml #{hero_class(@section)}"}
+        .wrapper
+          %p
+            = @section.name
 
 
   = content_for :meta_description do

--- a/app/views/layouts/section_home.html.haml
+++ b/app/views/layouts/section_home.html.haml
@@ -3,10 +3,11 @@
     = yield
 
   = content_for :after_header do
-    %div{class: "hero-med #{hero_class(@section)}"}
-      .wrapper
-        %h1
-          = @section.name
+    - unless @section.is_a? RootSection
+      %div{class: "hero-med #{hero_class(@section)}"}
+        .wrapper
+          %h1
+            = @section.name
 
   - if node.short_summary
     = content_for :meta_description do

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -12,17 +12,18 @@
 
 
 = content_for(:after_header) do
-  - if @section
-    %div{class: "hero-sml #{hero_class(@section)}"}
-      .wrapper
-        %p
-          = @section.name
-  - else
-    .hero-med
-      .wrapper
-        %h1 News
-        %p
-          Announcements, media releases, interviews, speeches and more from the Australian Government.
+  - unless @section.is_a? RootSection
+    - if @section
+      %div{class: "hero-sml #{hero_class(@section)}"}
+        .wrapper
+          %p
+            = @section.name
+    - else
+      .hero-med
+        .wrapper
+          %h1 News
+          %p
+            Announcements, media releases, interviews, speeches and more from the Australian Government.
 
 %article#content{class: "#{news_article_class}"}
   -# H1 not included in the hero bar for section news lists so include it here

--- a/db/migrate/20160826021047_update_root_section_with_root_node.rb
+++ b/db/migrate/20160826021047_update_root_section_with_root_node.rb
@@ -1,0 +1,7 @@
+class UpdateRootSectionWithRootNode < ActiveRecord::Migration[5.0]
+  def up
+    root = Node.root_node
+    root.associate_root_section
+    root.save()
+  end
+end

--- a/db/migrate/20160826021047_update_root_section_with_root_node.rb
+++ b/db/migrate/20160826021047_update_root_section_with_root_node.rb
@@ -1,7 +1,9 @@
 class UpdateRootSectionWithRootNode < ActiveRecord::Migration[5.0]
   def up
-    root = Node.root_node
-    root.associate_root_section
-    root.save()
+    if Node.root_node
+      root = Node.root_node
+      root.associate_root_section
+      root.save()
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -143,15 +143,6 @@ ActiveRecord::Schema.define(version: 20160826021047) do
     t.text     "image_url"
   end
 
-  create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", null: false
-    t.text     "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
-    t.index ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
-  end
-
   create_table "submissions", force: :cascade do |t|
     t.uuid     "revision_id",                    null: false
     t.integer  "submitter_id",                   null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160826021046) do
+ActiveRecord::Schema.define(version: 20160826021047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,15 @@ ActiveRecord::Schema.define(version: 20160826021046) do
     t.string   "cms_url"
     t.string   "cms_path"
     t.text     "image_url"
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+    t.index ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
   end
 
   create_table "submissions", force: :cascade do |t|

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe NodesController, :type => :controller do
   describe 'GET #show' do
     let!(:root_node) { Fabricate(:root_node) }
+    let!(:root) { Fabricate(:root_section, name: 'root')}
+    let!(:bar) { Fabricate(:general_content, name: 'bar',section: root, parent: Node.root_node)}
     let!(:foo) { Fabricate(:section, name: 'foo')}
     let!(:section_home) { Fabricate(:section_home, section: foo)}
 
@@ -39,6 +41,13 @@ RSpec.describe NodesController, :type => :controller do
       context 'given a page nested beneath another page' do
         it 'should return the page successfully' do
           get :show, params: { path: 'foo/zero/four/six' }
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context 'given a page nested beneath a root section' do
+        it 'should return the page successfully' do
+          get :show, params: { path: 'bar' }
           expect(response.status).to eq(200)
         end
       end

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe NodesController, :type => :controller do
   describe 'GET #show' do
     let!(:root_node) { Fabricate(:root_node) }
-    let!(:root) { Fabricate(:root_section, name: 'root')}
-    let!(:bar) { Fabricate(:general_content, name: 'bar',section: root, parent: Node.root_node)}
+    let!(:bar) { Fabricate(:general_content, name: 'bar',section: root_node.section, parent: Node.root_node)}
     let!(:foo) { Fabricate(:section, name: 'foo')}
     let!(:section_home) { Fabricate(:section_home, section: foo)}
 

--- a/spec/fabricators/section.rb
+++ b/spec/fabricators/section.rb
@@ -5,6 +5,10 @@ Fabricator(:section) do
   after_build { Fabricate(:root_node) unless Node.root_node }
 end
 
+Fabricator(:root_section, from: :section, class_name: :root_section) do
+  name { Fabricate.sequence(:root_section_name) { |i| "root_section-#{i}" } }
+end
+
 Fabricator(:agency, from: :section, class_name: :agency) do
   name { Fabricate.sequence(:agency_name) { |i| "agency-#{i}" } }
 end


### PR DESCRIPTION
RootNode child nodes do appear as root level pages but without a section, you can't find them in editorial or give access to edit those pages etc. 
This PR attempts to add a special section type that can hold a RootNode and relax some of the UI/validations to let users easily manage root level pages.