### PR TITLE
[SITES-647] Allow creating users through editorial

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
+# PORT the server is running on. For email links etc.
+PORT=3000
 # ROLLBAR_ACCESS_TOKEN=...
 # SEED_USER_PASSWORD=
 # MAILTRAP_USERNAME=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is influenced by http://keepachangelog.com/.
 - Phone number verification when changing numbers
 - Simple feedback system and admin
 - Rendering # links as placeholder spans
+- Section owners and admins can create new users
 
 ### Changed
 - Upgrade Rails to v5.0.0.1
@@ -21,6 +22,7 @@ This file is influenced by http://keepachangelog.com/.
 - Remove instances of permit! mass assignment
 - Improved accessibility
 - Switched to database backed session stores for greater security
+
 
 ## [v1.1.0] - 2016-08-23
 ### Added

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,10 @@
+class ConfirmationsController < Devise::ConfirmationsController
+  protected
+  def after_confirmation_path_for(resource_name, resource)
+    if params[:reset_password_token].present?
+      edit_password_path(resource, reset_password_token: params[:reset_password_token])
+    else
+      super
+    end
+  end
+end

--- a/app/controllers/editorial/users_controller.rb
+++ b/app/controllers/editorial/users_controller.rb
@@ -1,0 +1,35 @@
+module Editorial
+  class UsersController < EditorialController
+
+    before_action ->() { authorize! :create, :user }, only: [:new, :create]
+
+    def new
+      @form = UserForm.new(User.new)
+    end
+
+    def create
+      @form = UserForm.new(User.new)
+      if @form.validate(user_params)
+        @form.sync
+        tmp_password = SecureRandom.base64(12)
+        user = @form.model
+        user.password = tmp_password
+        user.password_confirmation = tmp_password
+        user.skip_confirmation_notification!
+        if user.save
+          user.send_invite_email
+          flash[:notice] = 'An email has been sent to the user inviting them to join GOV.AU'
+          redirect_to editorial_root_path and return
+        end
+      end
+      render :new
+    end
+
+    private
+
+    def user_params
+      params.required(:user).permit(:email, :first_name, :last_name)
+    end
+
+  end
+end

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -1,0 +1,9 @@
+class UserForm < Reform::Form
+  include Reform::Form::ActiveRecord
+  property :email
+  property :first_name
+  property :last_name
+
+  validates :email, presence: true, email_domain_whitelist: true
+  validates_uniqueness_of :email
+end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -14,4 +14,13 @@ class Notifier < ApplicationMailer
       end
     end
   end
+
+  def user_invite(user, reset_token)
+    @user = user
+    @url = user_confirmation_url(confirmation_token: @user.confirmation_token, reset_password_token: reset_token)
+    mail(to: user.email, subject: "Invitation to GOV.AU Beta") do |format|
+      format.text
+      format.html
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -71,6 +71,11 @@ class Ability
       can :review_in, Section do |section|
         user.has_cached_role? :reviewer, section
       end
+
+      can :create, :user do
+        # if owner of any section
+        user.roles.where(name: :owner).count > 0
+      end
     end
 
     # Everyone (signed in or not) can view published pages.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,4 +96,10 @@ class User < ApplicationRecord
     self.identity_verified_at = Time.now.utc
     save!
   end
+
+  def send_invite_email
+    # set_reset_password_token defined in devise recoverable
+    raw_token = set_reset_password_token
+    Notifier.user_invite(self, raw_token).deliver_later
+  end
 end

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -8,5 +8,5 @@
       = f.input :password, label: "New password", required: true, autofocus: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
       = f.input :password_confirmation, label: "Confirm your new password", required: true
     .form-actions
-      = f.button :submit, "Change my password"
+      = f.button :button, "Change my password"
   = render "devise/shared/links"

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -6,5 +6,5 @@
     .form-inputs
       = f.input :email, required: true, autofocus: true
     .form-actions
-      = f.button :submit, "Resend unlock instructions"
+      = f.button :button, "Resend unlock instructions"
   = render "devise/shared/links"

--- a/app/views/editorial/editorial/index.html.haml
+++ b/app/views/editorial/editorial/index.html.haml
@@ -14,3 +14,6 @@
         = link_to(section.name, editorial_section_path(section))
         - if can? :create_in, section
           = link_to('Create new page', prepare_editorial_section_nodes_path(section))
+
+- if can? :create, :user
+  = link_to('Create new user', new_editorial_user_path)

--- a/app/views/editorial/users/new.html.haml
+++ b/app/views/editorial/users/new.html.haml
@@ -1,0 +1,14 @@
+= content_for :title do
+  = "Create a user"
+
+- breadcrumb :new_editorial_user
+
+%h1 Create a user
+%p Invite a new user to join GOV.AU
+
+%div.form_wrapper
+  = simple_form_for([:editorial, @form]) do |f|
+    = f.input :email, as: :email
+    = f.input :first_name, required: false
+    = f.input :last_name, required: false
+    = f.button :button, 'Send invite'

--- a/app/views/notifier/user_invite.markerb
+++ b/app/views/notifier/user_invite.markerb
@@ -1,0 +1,11 @@
+Hi <%= @user.first_name %>,
+
+Welcome to GOV.AU Beta.
+
+To get started as a content author or reviewer please confirm your email address and follow the instructions.
+
+<<%= @url.html_safe %>>
+
+Thank you
+
+The GOV.AU Team

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -94,6 +94,11 @@ crumb :new_editorial_request do |section|
   parent :editorial_root
 end
 
+crumb :new_editorial_user do
+  link 'Create user', new_editorial_user_path
+  parent :editorial_root
+end
+
 crumb :public_news_articles do
   link 'News', news_articles_path
   parent :public_node, Node.root_node

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,8 +31,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  Rails.application.routes.default_url_options = { host: 'localhost', port: 3000 }
+  port = ENV['PORT'] || 3000
+  config.action_mailer.default_url_options = { host: 'localhost', port: port }
+  Rails.application.routes.default_url_options = { host: 'localhost', port: port }
 
   config.action_mailer.delivery_method = :letter_opener
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   match "/422", :to => "errors#change_rejected", :via => :all
   match "/500", :to => "errors#internal_server_error", :via => :all
 
-  devise_for :users, controllers: { registrations: 'registrations' }
+  devise_for :users, controllers: { registrations: 'registrations', confirmations: 'confirmations' }
 
   namespace :users do
     resource :two_factor_setup, only: [:new, :create, :update], controller: 'two_factor_setup' do
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
     get '/:section/news/:slug' => 'news#show', as: :news_article
 
     post '/news' => 'news#create'
+
+    resources :users, only: [:new, :create]
 
     get ':section_id' => 'sections#show', as: 'section'
     scope ':section_id', as: 'section' do

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ConfirmationsController, type: :controller do
+
+  before do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  describe '#show' do
+    let (:user) {Fabricate(:user, unconfirmed: true)}
+    let (:reset_token) { 'reset_token' }
+
+    context 'with reset token' do
+      subject { get :show, params: {confirmation_token: user.confirmation_token, reset_password_token: reset_token} }
+
+      it { is_expected.to redirect_to(edit_user_password_url(reset_password_token: :reset_token)) }
+    end
+
+    context 'without reset token' do
+      subject { get :show, params: {confirmation_token: user.confirmation_token} }
+
+      it { is_expected.to redirect_to(new_user_session_path) }
+    end
+  end
+
+
+end

--- a/spec/controllers/editorial/users_controller_spec.rb
+++ b/spec/controllers/editorial/users_controller_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Editorial::UsersController, type: :controller do
+  include ActiveJob::TestHelper
+
+  let!(:section) { Fabricate(:section) }
+  let(:owner) { Fabricate(:user, owner_of: section) }
+
+  before do
+    sign_in(owner)
+  end
+
+  describe '#new' do
+    subject { get :new }
+
+    it { is_expected.to be_success }
+  end
+
+  describe '#create' do
+    subject { post :create, params: {user: params} }
+
+    shared_examples 'succeed' do
+      it { is_expected.to redirect_to(editorial_root_path) }
+
+      it 'creates the user' do
+        expect { subject }.to change(User, :count).by(1)
+      end
+
+      it 'sends an email notification' do
+        perform_enqueued_jobs do
+          expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        end
+      end
+    end
+
+    context 'with valid params' do
+      let(:params) {{email: 'real@foo.gov.au', first_name: 'First', last_name: 'Last'}}
+
+      include_examples 'succeed'
+    end
+
+    context 'without name' do
+      let(:params) {{email: 'real@foo.gov.au'}}
+
+      include_examples 'succeed'
+    end
+
+    context 'with invalid email' do
+      let (:params) {{email: 'bad@bad'}}
+
+      it 'does not create the user' do
+        expect { subject }.not_to change(User, :count)
+      end
+    end
+  end
+
+end

--- a/spec/features/editorial_auth_spec.rb
+++ b/spec/features/editorial_auth_spec.rb
@@ -51,6 +51,7 @@ describe 'editorial authorisation:' do
         '/editorial/%{section_id}/requests/%{request_id}' => false,
         '/editorial/news'                           => false,
         '/editorial/news/new'                       => false,
+        '/editorial/users/new'                      => false,
     }
   end
 
@@ -70,6 +71,7 @@ describe 'editorial authorisation:' do
           '/editorial/%{section_id}/requests/%{request_id}' => true,
           '/editorial/news'                           => true,
           '/editorial/news/new'                       => false,
+          '/editorial/users/new'                      => false,
       }
     end
 
@@ -87,6 +89,7 @@ describe 'editorial authorisation:' do
           '/editorial/%{section_id}/requests/%{request_id}' => false,
           '/editorial/news'                           => true,
           '/editorial/news/new'                       => true,
+          '/editorial/users/new'                      => false,
       }
     end
 
@@ -104,6 +107,7 @@ describe 'editorial authorisation:' do
           '/editorial/%{section_id}/requests/%{request_id}' => false,
           '/editorial/news'                           => true,
           '/editorial/news/new'                       => false,
+          '/editorial/users/new'                      => false,
       }
     end
 
@@ -121,6 +125,7 @@ describe 'editorial authorisation:' do
           '/editorial/%{section_id}/requests/%{request_id}' => true,
           '/editorial/news'                           => true,
           '/editorial/news/new'                       => false,
+          '/editorial/users/new'                      => true,
       }
     end
 
@@ -138,6 +143,7 @@ describe 'editorial authorisation:' do
           '/editorial/%{section_id}/requests/%{request_id}' => true,
           '/editorial/news'                           => true,
           '/editorial/news/new'                       => true,
+          '/editorial/users/new'                      => true,
       }
     end
   end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -52,4 +52,20 @@ RSpec.describe Notifier, type: :mailer do
       let!(:content) { requester.email }
     end
   end
+
+  describe '#user_invite' do
+    let(:user) { Fabricate(:user) }
+    let(:reset_token) { 'reset_token' }
+    let(:mail) { described_class.user_invite(user, reset_token).deliver_now }
+
+    it_behaves_like 'a multipart email'
+
+    it 'sends to the user' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it_behaves_like 'has content' do
+      let!(:content) { reset_token }
+    end
+  end
 end

--- a/spec/mailers/previews/notifier_preview.rb
+++ b/spec/mailers/previews/notifier_preview.rb
@@ -3,4 +3,10 @@ class NotifierPreview < ActionMailer::Preview
   def author_request
     Notifier.author_request(Request.first)
   end
+
+  def user_invite
+    u = User.first
+    u.confirmation_token = 'confirmation_token'
+    Notifier.user_invite(u, 'reset_password_token')
+  end
 end


### PR DESCRIPTION
Creating a new user sends an invite email to the user. When they click the link it sends them to the confirmation page which redirects to the password reset page.

This PR does not remove the registration pages. That's coming later.

![image](https://cloud.githubusercontent.com/assets/4583474/18038626/c4fe2048-6ddd-11e6-8141-353382624f33.png)
