### PR TITLE
Feature/telephone numbers govau 322

### DIFF
--- a/app/assets/stylesheets/_phone-numbers.scss
+++ b/app/assets/stylesheets/_phone-numbers.scss
@@ -1,0 +1,90 @@
+.highlighted {
+  background: $focus-colour;
+  box-decoration-break: clone;
+  box-shadow: .75 * $tiny-spacing 0 0 $focus-colour, -.75 * $tiny-spacing 0 0 $focus-colour;
+  display: inline;
+}
+
+.list-horizontal {
+
+  > li {
+
+    .offset-title {
+
+      @include media($tablet) {
+        flex: 0 0 35%;
+        margin-right: $base-spacing;
+      }
+
+      h2,
+      h3,
+      h4 {
+        font-size: rem(26);
+        font-weight: $base-font-weight;
+
+        @include media($tablet) {
+          font-size: rem(36);
+        }
+
+        span {
+          display: block;
+          font-size: rem(17);
+          font-weight: $heading-font-weight;
+        }
+      }
+
+      + article ul,
+      + div ul {
+        list-style: none;
+        margin-top: 0;
+        padding-left: 0;
+      }
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &.offset-item {
+      border-top: 0;
+      border-bottom: solid 1px $border-colour;
+      padding-left: 0;
+      padding-right: $base-spacing;
+
+      &:last-child {
+        border-bottom: solid 1px $border-colour;
+        border-top: 0;
+      }
+
+      &:first-child {
+        border-top: solid 1px $border-colour;
+      }
+
+      .number-descriptor {
+        @include outer-container;
+
+        li {
+          @include media($mobile) {
+            @include span-columns(3 of 6);
+            @include omega(2n);
+          }
+
+          h5 {
+            font-size: rem(16);
+          }
+        }
+      }
+    }
+
+    &.highlighted-item {
+      background-color: $callout-bg-light-colour;
+      padding-left: $base-spacing;
+
+      .offset-title h2,
+      .offset-title h3,
+      .offset-title h4 {
+        font-size: rem(70);
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,9 +28,10 @@
  @import "times-dates-list"; //waiting for https://github.com/AusDTO/gov-au-ui-kit/pull/211 - will require html refactor
  @import "lists-ie-fix"; //github issue raised for these overrides with UI Kit https://github.com/AusDTO/gov-au-ui-kit/issues/258
  @import "tab-overrides"; //treb and Alz will address updating the styling of this in UI Kit
- @import "sign-in";
- @import "category-accordions";
- @import "category-page-popular-now";
+ @import "sign-in"; //UI Kit is not looking at page components like this quite yet
+ @import "category-accordions"; //these can get refactored out when incorporated into UI Kit
+ @import "category-page-popular-now"; //To Do - raise GitHub issue
+ @import "phone-numbers"; //GitHub issue raised https://github.com/AusDTO/gov-au-ui-kit/issues/270
 
  // These have questions raised on ui-kit for whether they want to include it or if it should
  // be our custom stuff

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,7 +31,7 @@
  @import "sign-in"; //UI Kit is not looking at page components like this quite yet
  @import "category-accordions"; //these can get refactored out when incorporated into UI Kit
  @import "category-page-popular-now"; //To Do - raise GitHub issue
- @import "phone-numbers"; //GitHub issue raised https://github.com/AusDTO/gov-au-ui-kit/issues/270
+ @import "phone-numbers"; //GitHub issue raised view more info at https://github.com/AusDTO/gov-au-ui-kit/pull/319
 
  // These have questions raised on ui-kit for whether they want to include it or if it should
  // be our custom stuff


### PR DESCRIPTION
The PR adds custom css required to style the Australian numbers page. This will close [GOVAU-322]

Currently this page is built by inserting the necessary HTML into the WYSIWYG. This tech debt has been acknowledged in [SITES-661]

The custom CSS has been sent to the UI Kit as both a PR and a GitHub issue.
https://github.com/AusDTO/gov-au-ui-kit/pull/319
https://github.com/AusDTO/gov-au-ui-kit/issues/270
