### PR TITLE
Fix highlighted list item visual defect #463

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This file is influenced by http://keepachangelog.com/.
 
 ### Fixed
 - Fixed issue where the 'Popular now' heading on Category pages was displaying even if there were no Popular now links
+- Fixed visual defect with box-shadow being incorrectly displayed on School holiday highlighted list items
+
 
 ## [v1.2.0] - 2016-08-31
 ### Added

--- a/app/views/templates/custom/school_holidays_act.html.erb
+++ b/app/views/templates/custom/school_holidays_act.html.erb
@@ -32,7 +32,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -50,7 +50,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -68,7 +68,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -86,7 +86,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -110,7 +110,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -128,7 +128,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -146,7 +146,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -164,7 +164,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays

--- a/app/views/templates/custom/school_holidays_nsw.html.erb
+++ b/app/views/templates/custom/school_holidays_nsw.html.erb
@@ -32,7 +32,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -50,7 +50,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -68,7 +68,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -86,7 +86,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -113,7 +113,7 @@
   </li>
 
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -131,7 +131,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -149,7 +149,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -167,7 +167,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays

--- a/app/views/templates/custom/school_holidays_nt.html.erb
+++ b/app/views/templates/custom/school_holidays_nt.html.erb
@@ -32,7 +32,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -50,7 +50,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -68,7 +68,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -86,7 +86,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -113,7 +113,7 @@
   </li>
 
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -131,7 +131,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -149,7 +149,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -167,7 +167,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -178,4 +178,3 @@
   </li>
 
 </ul>
-

--- a/app/views/templates/custom/school_holidays_qld.html.erb
+++ b/app/views/templates/custom/school_holidays_qld.html.erb
@@ -32,7 +32,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -50,7 +50,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -68,7 +68,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -87,7 +87,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -112,7 +112,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -130,7 +130,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -148,7 +148,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -167,7 +167,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays

--- a/app/views/templates/custom/school_holidays_sa.html.erb
+++ b/app/views/templates/custom/school_holidays_sa.html.erb
@@ -32,7 +32,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -50,7 +50,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -68,7 +68,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -86,7 +86,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -110,7 +110,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -128,7 +128,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -146,7 +146,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -164,7 +164,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays

--- a/app/views/templates/custom/school_holidays_tas.html.erb
+++ b/app/views/templates/custom/school_holidays_tas.html.erb
@@ -32,7 +32,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -50,7 +50,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -68,7 +68,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -86,7 +86,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -110,7 +110,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -128,7 +128,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -146,7 +146,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -164,7 +164,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays

--- a/app/views/templates/custom/school_holidays_vic.html.erb
+++ b/app/views/templates/custom/school_holidays_vic.html.erb
@@ -32,7 +32,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -50,7 +50,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -68,7 +68,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -86,7 +86,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -110,7 +110,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -128,7 +128,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -146,7 +146,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -164,7 +164,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -174,4 +174,3 @@
   </li>
 
 </ul>
-

--- a/app/views/templates/custom/school_holidays_wa.html.erb
+++ b/app/views/templates/custom/school_holidays_wa.html.erb
@@ -32,7 +32,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -50,7 +50,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -68,7 +68,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -86,7 +86,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays
@@ -110,7 +110,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Autumn holidays
@@ -128,7 +128,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Winter holidays
@@ -146,7 +146,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Spring holidays
@@ -164,7 +164,7 @@
     </article>
   </li>
 
-  <li class="highlighted">
+  <li class="highlighted-item">
     <article>
       <h3>
         Summer holidays


### PR DESCRIPTION
This PR replaces the `.highlighted` class on Australian school dates list items with the correct `.highlighted-item` class. 

This fixes the visual defect #463 