### PR TITLE
[SITES-675] - Popular now links bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This file is influenced by http://keepachangelog.com/.
 - Removed 30 day grace window on 2FA
 
 ### Fixed
-
+- Fixed issue where the 'Popular now' heading on Category pages was displaying even if there were no Popular now links
 
 ## [v1.2.0] - 2016-08-31
 ### Added

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -8,16 +8,17 @@
     .wrapper
       %h1= @category.name
       %p= @category.summary
-      .links-group
-        %h2 Popular now
-        %ul
-          - @category.sections.each do |section|
-            - if not section.home_node.options.suppress_in_nav
-              - if section.home_node.state.draft?
-                %li
-                  %span.placeholder-link= section.name
-              - else
-                %li=link_to(section.name, nodes_path(section.slug))
+      - if not @category.sections.empty?
+        .links-group
+          %h2 Popular now
+          %ul
+            - @category.sections.each do |section|
+              - if not section.home_node.options.suppress_in_nav
+                - if section.home_node.state.draft?
+                  %li
+                    %span.placeholder-link= section.name
+                - else
+                  %li=link_to(section.name, nodes_path(section.slug))
 
 %article.content-main
   - @category.children.each do |subcategory|


### PR DESCRIPTION
This PR closes SITES-675

This PR fixes an issue where the 'Popular now' heading on Category pages was displaying even if there were no Popular now links

![popular-now-bug](https://cloud.githubusercontent.com/assets/12635736/18155673/3db1bd7a-7053-11e6-975b-016f65db12fd.png)
