### PR TITLE
[SITES-643] limit 2fa retries for identity verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is influenced by http://keepachangelog.com/.
 - Added 'What is GOV.AU Beta?' callout to homepage
 
 ### Changed
+- Incorrect attempts at verifying identity locks the user out
 
 ### Fixed
 - Markdown support for images with links

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -29,6 +29,7 @@ class UserDashboard < Administrate::BaseDashboard
     bypass_tfa: Field::Boolean,
     account_verified: Field::Boolean,
     phone_number: Field::String,
+    second_factor_attempts_count: Field::Number,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -62,6 +63,7 @@ class UserDashboard < Administrate::BaseDashboard
     :bypass_tfa,
     :account_verified,
     :phone_number,
+    :second_factor_attempts_count,
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -78,7 +80,8 @@ class UserDashboard < Administrate::BaseDashboard
     :roles,
     :bypass_tfa,
     :account_verified,
-    :phone_number
+    :phone_number,
+    :second_factor_attempts_count,
   ].freeze
 
   # Overwrite this method to customize how users are displayed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,7 +94,7 @@ class User < ApplicationRecord
 
   def confirm_identity!
     self.identity_verified_at = Time.now.utc
-    self.second_factor_atutempts_count = 0
+    self.second_factor_attempts_count = 0
     save!
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,6 +94,7 @@ class User < ApplicationRecord
 
   def confirm_identity!
     self.identity_verified_at = Time.now.utc
+    self.second_factor_atutempts_count = 0
     save!
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,7 +267,7 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 
-  config.max_login_attempts = 3  # Maximum second factor attempts count.
+  config.max_login_attempts = 10  # Maximum second factor attempts count.
   config.allowed_otp_drift_seconds = 30  # Allowed TOTP time drift between client and server.
   config.otp_length = 6  # TOTP code length
   config.direct_otp_valid_for = 5.minutes  # Time before direct OTP becomes invalid


### PR DESCRIPTION
Limits a user's ability to verify their identity with 2FA