### PR TITLE
SITES-656 redirect authentication failures to /users/sign_in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is influenced by http://keepachangelog.com/.
 ### Changed
 
 ### Fixed
+- Auth failure in /editorial now redirected to /users/sign_in
 
 
 ## [v1.3.0] - 2016-09-07

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -7,6 +7,7 @@
 module Admin
   class ApplicationController < Administrate::ApplicationController
     include ::IncompleteTfaSetup
+    include ::AccessDeniedConcern
 
     before_action ->() { authorize! :manage, :all }
     before_action :complete_two_factor_setup
@@ -27,13 +28,6 @@ module Admin
     # def records_per_page
     #   params[:per_page] || 20
     # end
-
-    rescue_from CanCan::AccessDenied do |exception|
-      respond_to do |format|
-        format.html { redirect_to new_user_session_path, :alert => exception.message }
-        format.json { render status: :unauthorized, json: { message: exception.message } }
-      end
-    end
 
     def append_info_to_payload(payload)
       super

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,12 +23,7 @@ class ApplicationController < ActionController::Base
     LoggingHelper.log_event(request, current_user, {event: event}.merge(attrs))
   end
 
-  rescue_from CanCan::AccessDenied do |exception|
-    respond_to do |format|
-      format.html { redirect_to root_url, :alert => exception.message }
-      format.json { render status: :unauthorized, json: { message: exception.message } }
-    end
-  end
+  include AccessDeniedConcern
 
   def current_user
     super

--- a/app/controllers/concerns/access_denied_concern.rb
+++ b/app/controllers/concerns/access_denied_concern.rb
@@ -1,0 +1,20 @@
+module AccessDeniedConcern
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from CanCan::AccessDenied do |exception|
+      respond_to do |format|
+        format.html do
+          if user_signed_in?
+            flash[:alert] = "You are not authorized to access this page."
+            render 'errors/unauthorized', :status => :unauthorized
+          else
+            redirect_to new_user_session_path, :alert =>  "You must sign in to access the requested page."
+          end
+        end
+        format.json { render status: :unauthorized, json: { message: exception.message } }
+      end
+    end
+  end
+end
+

--- a/app/controllers/concerns/access_denied_concern.rb
+++ b/app/controllers/concerns/access_denied_concern.rb
@@ -6,7 +6,7 @@ module AccessDeniedConcern
       respond_to do |format|
         format.html do
           if user_signed_in?
-            flash[:alert] = "You are not authorized to access this page."
+            flash[:alert] = "You are not authorised to access this page."
             render 'errors/unauthorized', :status => :unauthorized
           else
             redirect_to new_user_session_path, :alert =>  "You must sign in to access the requested page."

--- a/app/views/errors/unauthorized.html.haml
+++ b/app/views/errors/unauthorized.html.haml
@@ -1,0 +1,7 @@
+= content_for :title do
+  You are not authorised to access this page (401)
+
+%article.content-main.callout--calendar-event
+  %h1 You are not authorised to access this page (401)
+  %p If you are the application owner check the logs for more information.
+

--- a/spec/concerns/access_denied_concern_spec.rb
+++ b/spec/concerns/access_denied_concern_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe AccessDeniedConcern, type: :controller do
+
+  controller(ActionController::Base) do
+    include AccessDeniedConcern
+
+    before_action do
+      authorize! :read, :index
+    end
+
+    def index
+      render :nothing => true
+    end
+  end
+
+  let(:user) { Fabricate(:user) }
+
+  # See: https://github.com/CanCanCommunity/cancancan/wiki/Testing-Abilities#controller-testing
+  let(:ability) do
+    Object.new.tap{|obj| obj.extend(CanCan::Ability)}
+  end
+
+  context 'when user is not signed in' do
+    context 'the controller' do
+      before { get :index }
+      subject { @controller }
+      it { is_expected.to set_flash[:alert].to("You must sign in to access the requested page.") }
+    end
+
+    context 'the response' do
+      subject { get :index }
+      it { is_expected.to redirect_to(new_user_session_path) }
+    end
+  end
+
+  context 'when user is signed in but not authorized' do
+    before(:each) do
+      ability.cannot :read, :index
+      allow(@controller).to receive(:current_ability).and_return(ability) 
+      sign_in(user)
+    end
+
+    after(:each) do
+      sign_out(user)
+    end
+
+    context 'the controller' do
+      before { get :index }
+      subject { @controller }
+      it { is_expected.to set_flash[:alert].to("You are not authorized to access this page.") }
+    end
+
+    context 'the response' do
+      subject { get :index }
+      it { is_expected.to have_http_status(:unauthorized) }
+    end
+  end
+end
+
+

--- a/spec/concerns/access_denied_concern_spec.rb
+++ b/spec/concerns/access_denied_concern_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe AccessDeniedConcern, type: :controller do
     end
   end
 
-  context 'when user is signed in but not authorized' do
+  context 'when user is signed in but not authorised' do
     before(:each) do
       ability.cannot :read, :index
       allow(@controller).to receive(:current_ability).and_return(ability) 
@@ -48,7 +48,7 @@ RSpec.describe AccessDeniedConcern, type: :controller do
     context 'the controller' do
       before { get :index }
       subject { @controller }
-      it { is_expected.to set_flash[:alert].to("You are not authorized to access this page.") }
+      it { is_expected.to set_flash[:alert].to("You are not authorised to access this page.") }
     end
 
     context 'the response' do

--- a/spec/controllers/editorial/editorial_controller_spec.rb
+++ b/spec/controllers/editorial/editorial_controller_spec.rb
@@ -42,15 +42,5 @@ RSpec.describe Editorial::EditorialController, type: :controller do
         end
       end
     end
-
-    context 'when user is not authenticated' do
-      before do
-        authenticated_request
-      end
-
-      it { is_expected.to set_flash[:alert].to("You are not authorized to access this page.") }
-    end
   end
-
-
 end

--- a/spec/controllers/editorial/news_controller_spec.rb
+++ b/spec/controllers/editorial/news_controller_spec.rb
@@ -10,25 +10,6 @@ RSpec.describe Editorial::NewsController, type: :controller do
   let!(:section_c) { Fabricate(:section) }
   let!(:user) { Fabricate(:user, author_of: section_a, reviewer_of: section_b) }
 
-  describe 'GET #new' do
-    context 'when a user is authorised' do
-      before { sign_in(user) }
-
-      context 'with a blank form' do
-        subject { get :new }
-
-        it { is_expected.to be_success }
-      end
-    end
-
-    context 'when a user is not authorised' do
-      before { get :new }
-
-      it { is_expected.to redirect_to(root_path) }
-      it { is_expected.to set_flash[:alert].to('You are not authorized to access this page.') }
-    end
-  end
-
   describe 'POST #create' do
     context 'when a user is authorised' do
       context 'with valid date' do
@@ -83,40 +64,6 @@ RSpec.describe Editorial::NewsController, type: :controller do
         }
 
         it { is_expected.to render_template :new }
-      end
-    end
-
-    context 'when a user is not authorised' do
-      let(:post_action) {
-        post :create, node: {
-            name: 'Test',
-            section_id: section_a.id,
-            short_summary: 'foo',
-            summary: 'bar',
-            content_body: 'foobar',
-            release_date: Date.today,
-            section_ids: [section_b.id]
-        }
-      }
-      let!(:submission) { Fabricate(:submission) }
-
-      before do
-        post_action
-      end
-
-      it { is_expected.to set_flash[:alert].to('You are not authorized to access this page.') }
-      it { is_expected.to redirect_to(root_path) }
-
-      it 'should not create a submission' do
-        expect {
-          post_action
-        }.to_not change(Submission, :count)
-      end
-
-      it 'should not create a node' do
-        expect {
-          post_action
-        }.to_not change(Node, :count)
       end
     end
   end
@@ -175,17 +122,6 @@ RSpec.describe Editorial::NewsController, type: :controller do
           expect(news.section_ids).to match_array([section_a.id, section_b.id])
         end
       end
-    end
-
-    context 'when a user is not authenticated' do
-      let!(:post_action) {
-        post :update, id: article.id, node: {
-          section_id: section_a
-        }
-      }
-
-      it { is_expected.to redirect_to root_path }
-      it { is_expected.to set_flash[:alert].to('You are not authorized to access this page.') }
     end
   end
 end

--- a/spec/controllers/editorial/nodes_controller_spec.rb
+++ b/spec/controllers/editorial/nodes_controller_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe Editorial::NodesController, type: :controller do
       it { is_expected.to assign_to(:nodes).with section.nodes.decorate }
     end
 
-    context 'when user is not authorised' do
-      before { authenticated_request }
-
-      it { is_expected.to set_flash[:alert].to("You are not authorized to access this page.") }
-    end
-
     context 'when user is a reviewer' do
       before { sign_in(reviewer) }
       after { sign_out(reviewer) }

--- a/spec/features/editorial_auth_spec.rb
+++ b/spec/features/editorial_auth_spec.rb
@@ -13,7 +13,7 @@ describe 'editorial authorisation:' do
   let!(:request) { Fabricate(:request, section: section, user: no_roles_user) }
 
   shared_examples_for 'as not authenticated' do |path_map|
-    path_map.each do |path, is_authorized|
+    path_map.each do |path, is_authorised|
       context "on #{path}" do
         before { visit (path % {section_id: section.id, node_id: section.home_node.id, request_id: request.id}) }
         it 'as not authenticated' do
@@ -23,26 +23,26 @@ describe 'editorial authorisation:' do
     end
   end
 
-  shared_examples_for 'as not authorized' do
-    it 'as not authorized' do
-      expect(page).to have_content('You are not authorized to access this page.')
+  shared_examples_for 'as not authorised' do
+    it 'as not authorised' do
+      expect(page).to have_content('You are not authorised to access this page.')
     end
   end
 
-  shared_examples_for 'as authorized' do
-    it 'as authorized' do
-      expect(page).to have_no_content('You are not authorized to access this page.')
+  shared_examples_for 'as authorised' do
+    it 'as authorised' do
+      expect(page).to have_no_content('You are not authorised to access this page.')
     end
   end
 
   shared_examples 'verify authorization' do |path_map|
-    path_map.each do |path, is_authorized|
+    path_map.each do |path, is_authorised|
       context "on #{path}" do
         before { visit (path % {section_id: section.id, node_id: section.home_node.id, request_id: request.id}) }
-        if is_authorized
-          include_examples 'as authorized'
+        if is_authorised
+          include_examples 'as authorised'
         else
-          include_examples 'as not authorized'
+          include_examples 'as not authorised'
         end
       end
     end

--- a/spec/features/editorial_auth_spec.rb
+++ b/spec/features/editorial_auth_spec.rb
@@ -12,16 +12,26 @@ describe 'editorial authorisation:' do
   let!(:no_roles_user) { Fabricate(:user) }
   let!(:request) { Fabricate(:request, section: section, user: no_roles_user) }
 
+  shared_examples_for 'as not authenticated' do |path_map|
+    path_map.each do |path, is_authorized|
+      context "on #{path}" do
+        before { visit (path % {section_id: section.id, node_id: section.home_node.id, request_id: request.id}) }
+        it 'as not authenticated' do
+          expect(page).to have_content('You must sign in to access the requested page.')
+        end
+      end
+    end
+  end
+
   shared_examples_for 'as not authorized' do
     it 'as not authorized' do
-      expect(page.current_path).to eq('/')
-      expect(page).to have_content('You are not authorized to access this page')
+      expect(page).to have_content('You are not authorized to access this page.')
     end
   end
 
   shared_examples_for 'as authorized' do
     it 'as authorized' do
-      expect(page).to have_no_content('You are not authorized to access this page')
+      expect(page).to have_no_content('You are not authorized to access this page.')
     end
   end
 
@@ -39,19 +49,20 @@ describe 'editorial authorisation:' do
   end
 
   context 'an unauthenticated user' do
-    it_behaves_like 'verify authorization', {
-        '/editorial'                                => false,
-        '/editorial/%{section_id}'                  => false,
-        '/editorial/%{section_id}/nodes/prepare'    => false,
-        '/editorial/%{section_id}/nodes/new'        => false,
-        '/editorial/%{section_id}/nodes/%{node_id}' => false,
-        '/editorial/%{section_id}/nodes/%{node_id}/edit' => false,
-        '/editorial/%{section_id}/submissions/new?node_id=%{node_id}' => false,
-        '/editorial/%{section_id}/requests/new'     => false,
-        '/editorial/%{section_id}/requests/%{request_id}' => false,
-        '/editorial/news'                           => false,
-        '/editorial/news/new'                       => false,
-        '/editorial/users/new'                      => false,
+    before { logout }
+    it_behaves_like 'as not authenticated', {
+      '/editorial'                                => false,
+      '/editorial/%{section_id}'                  => false,
+      '/editorial/%{section_id}/nodes/prepare'    => false,
+      '/editorial/%{section_id}/nodes/new'        => false,
+      '/editorial/%{section_id}/nodes/%{node_id}' => false,
+      '/editorial/%{section_id}/nodes/%{node_id}/edit' => false,
+      '/editorial/%{section_id}/submissions/new?node_id=%{node_id}' => false,
+      '/editorial/%{section_id}/requests/new'     => false,
+      '/editorial/%{section_id}/requests/%{request_id}' => false,
+      '/editorial/news'                           => false,
+      '/editorial/news/new'                       => false,
+      '/editorial/users/new'                      => false,
     }
   end
 


### PR DESCRIPTION
Authentication behaviour is now handled by using the AccessDeniedConcern
in appropriate controllers. This centralises the behaviour for
consitency. The behaviour is:

- When a user is not authenticated:

  If they try to access a page that requires authorisation they will be
  redirected to /users/sign_in

  If it's a public page the request will succeed

- When a user is authenticated:

  If the user is also authorised the request will succeed.
  If they are not authorised the request will fail with a 401.

The flash messages are also set by the helper.

I deleted some of the specs for various controllers that were testing
the very rudimentary behaviour of how authentication and authorisation
failures were handled.  The basics are now tested in the spec for the
AccessDeniedConcern itself so I removed the duplication.
