### PR TITLE
remove release date content from homepage

### DIFF
--- a/app/views/layouts/root.html.haml
+++ b/app/views/layouts/root.html.haml
@@ -67,8 +67,6 @@
               This minimal viable product (MVP) — a small piece of the bigger picture
               — demonstrates our thinking around design, content and technology.
             %li
-              A public release is scheduled for late 2017.
-            %li
               More links will be activated as new content is added.
             %li
               GOV.AU is a

--- a/app/views/templates/root_node.html.haml
+++ b/app/views/templates/root_node.html.haml
@@ -91,27 +91,30 @@
       %li
         %article
           %h3
-            %a{:href => "#"} Just had a baby?
+            %span.placeholder-link
+              Just had a baby?
           %p
             Get your baby on your Medicare card, registered for child care
             payments and immunised.
-          %a{:href => "#", :role => "button"} Get started
+          %a{:href => "#", :role => "button", :disabled => true} Get started
       %li
         %article
           %h3
-            %a{:href => "#"} Helping an older person?
+            %span.placeholder-link
+              Helping an older person?
           %p
             Find support for older Australians wanting to stay at home or
             needing other living arrangements.
-          %a{:href => "#", :role => "button"} Get started
+          %a{:href => "#", :role => "button", :disabled => true} Get started
       %li
         %article
           %h3
-            %a{:href => "#"} Starting a business?
+            %span.placeholder-link
+              Starting a business?
           %p
             Tell us about your business idea and we'll match the right
             government information to your set-up.
-          %a{:href => "#", :role => "button"} Get started
+          %a{:href => "#", :role => "button", :disabled => true} Get started
 
   %section.about-australia
     %h2.home-heading About Australia


### PR DESCRIPTION
This PR removes the dot point from the homepage that described the public release date 