### PR TITLE
Pluralise 'ministers' only where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This file is influenced by http://keepachangelog.com/.
 ### Changed
 
 ### Fixed
-
+- Pluralise 'ministers' only where appropriate
 
 ## [v1.3.1] - 2016-09-07
 ### Added

--- a/app/views/templates/_related_ministers.html.haml
+++ b/app/views/templates/_related_ministers.html.haml
@@ -1,5 +1,5 @@
 - if related_ministers.present?
-  %h2 Our ministers
+  %h2= 'Our ' + (related_ministers.count == 1 ? 'minister': 'ministers')
   %ul.list-horizontal
     - related_ministers.each do |minister|
       - id = "minister-summary-#{minister.name.parameterize}"


### PR DESCRIPTION
Fixes #487 

![](https://cloud.githubusercontent.com/assets/81432/18331730/873992d2-75a4-11e6-8715-797296f4af00.png)
