### PR TITLE
stop window from jumping down upon checkbox selection in overflo…

### DIFF
--- a/vendor/assets/stylesheets/_ui-kit.scss
+++ b/vendor/assets/stylesheets/_ui-kit.scss
@@ -5975,7 +5975,7 @@ form {
       height: 1px;
       // hide the native widget but keep it in the tab order
       left: -10000px;
-      position: absolute;
+      position: relative;
       visibility: visible;
       width: 1px;
 


### PR DESCRIPTION
This bug affects checkboxes in accordions with overflow.

The impact would be that for checkboxes far down in the accordion, a selection would make the screen jump down to where the checkbox would exist without the overflow on that area.

This is technically a UIKIT bug, but we should be pragmatic and merge this in advance of an update from them.