### PR TITLE
SITES-712 do not use aws-provider in git secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ $EDITOR .env
 		$ cd $YOUR_PROJECT_WORKDIR
 		$ git secrets --install
 		$ git secrets --add-provider ./git-secret-patterns.rb
-		$ git secrets --register-aws
 
 2. Commits that introduce files containing matching illegal patterns will be aborted.
 

--- a/git-secret-patterns.rb
+++ b/git-secret-patterns.rb
@@ -6,8 +6,6 @@
 # To install git-secrets, run `brew install git-secrets` then in the project directory
 # run `git secrets --install`, then `git secrets --add-provider ./git-secret-patterns.rb`.
 #
-# Additionally patterns for AWS may be installed by running `git secrets --register-aws`.
-#
 # This file contains a list of patterns that will cause a commit to be aborted
 # if any change that the commit introduces contains lines matching any of these
 # patterns.


### PR DESCRIPTION
The aws-provider echos personal AWS creds to STDOUT to be used as a
pattern. If it echos no creds (if you have no personal AWS creds) the
response is treated like a pattern that matches EVERYTHING which is not
what we want. The is a bug in git-secrets.