### PR TITLE
Ensure GA tracking is called asynchronously

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,14 @@
 //= require "cable"
 //= require analytics.js
 
+$(document).ready(function() {
+  var ga_id = $('body').data('ga-id');
+  if (ga_id) {
+    ga('create', ga_id, 'auto');
+    ga('send', 'pageview');
+  }
+});
+
 //set breakpoint for accordions to collapse at
 var width = 520;
 

--- a/app/views/application/_ga.html.haml
+++ b/app/views/application/_ga.html.haml
@@ -1,4 +1,0 @@
-- if ENV['GA_TRACKING_ID']
-  :javascript
-    ga('create', '#{ENV["GA_TRACKING_ID"]}', 'auto');
-    ga('send', 'pageview');

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,7 @@
 <html lang="en-AU" class="no-js"><!--<![endif]-->
 
 = render 'application/head',  title: (content_for?(:title) ? "#{yield(:title)} | GOV.AU" : 'GOV.AU' )
-%body
+%body{data: { 'ga-id' => ENV['GA_TRACKING_ID'] }}
   = render 'application/google_tag_manager'
   %div.skip-to
     %a{href: "#content"}
@@ -72,7 +72,5 @@
             &copy; Commonwealth of Australia
             %br
             %a{href:'http://creativecommons.org/licenses/by/3.0/au/'} This work is licensed under a Creative Commons Attribution 3.0 International License
-
-= render 'application/ga'
 
 </html>


### PR DESCRIPTION
This approach guarantees that google analytics calls don't get made before everything has loaded. It also allows the analytics source code to be placed in the asset pipeline.