### PR TITLE
hide responsive menu when no unsuppressed nodes exist

### DIFF
--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -4,11 +4,11 @@
 
 %aside.sidebar
   %nav.local-nav{'aria-label' => 'main navigation'}
-    %h1.is-visuallyhidden
-      Menu
-    -if menu_nodes.present?
+    - if menu_nodes.present? && ((unsuppressed_nodes = menu_nodes.reject { |n| n.options.suppress_in_nav }).present?)
+      %h1.is-visuallyhidden
+        Menu
       %ul
         %li
           = link_to @section.name, public_node_path(@section.home_node), class: menu_node_class(@section.home_node, active_chain)
           %ul
-            = render partial: 'navbar_part', locals: { nodes: menu_nodes, depth: 3, active_chain: active_chain }
+            = render partial: 'navbar_part', locals: { nodes: unsuppressed_nodes, depth: 3, active_chain: active_chain }

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -3,8 +3,8 @@
 - active_chain = menu_active_chain(active)
 
 %aside.sidebar
-  %nav.local-nav{'aria-label' => 'main navigation'}
-    - if menu_nodes.present? && ((unsuppressed_nodes = menu_nodes.reject { |n| n.options.suppress_in_nav }).present?)
+  - if menu_nodes.present? && ((unsuppressed_nodes = menu_nodes.reject { |n| n.options.suppress_in_nav }).present?)
+    %nav.local-nav{'aria-label' => 'main navigation'}
       %h1.is-visuallyhidden
         Menu
       %ul


### PR DESCRIPTION
Fixes the responsive menu aside being visible when there is no menu to render

![image](https://cloud.githubusercontent.com/assets/5369670/19422632/2b80ed86-9463-11e6-876a-469fe169c0b6.png)

vs

![image](https://cloud.githubusercontent.com/assets/5369670/19422646/59fcd648-9463-11e6-9f63-2b52bbd1c78a.png)
