### PR TITLE
fix password reset mailer redirecting users to incorrect domain

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,8 +21,13 @@ PORT=3000
 # AWS_S3_ACCESS_KEY_ID=
 # AWS_S3_SECRET_ACCESS_KEY=
 
+# Base URL for editorial app
+# EDITORIAL_BASE_URL=
+
 # By default two-factor is disabled in development and enabled in other environments.
 # Use the following to override if necessary.
 # FORCE_2FA=true
 # DISABLE_2FA=true
 # TFA_SECRET_KEY=
+
+

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,4 +32,9 @@ module ApplicationHelper
       end
     end
   end
+
+
+  def editorial_url_for(path)
+    "#{Rails.configuration.editorial_base_url}#{path}"
+  end
 end

--- a/app/mailers/govau_mailer.rb
+++ b/app/mailers/govau_mailer.rb
@@ -1,0 +1,5 @@
+class GovauMailer < Devise::Mailer
+  helper :application
+  include Devise::Controllers::UrlHelpers
+  default template_path: 'devise/mailer'
+end

--- a/app/views/devise/mailer/confirmation_instructions.markerb
+++ b/app/views/devise/mailer/confirmation_instructions.markerb
@@ -4,7 +4,7 @@ Welcome to GOV.AU Beta.
 
 To get started as a content author or reviewer please confirm your email address and follow the instructions.
 
-[Click here to confirm your email address.](<%= confirmation_url(@resource, confirmation_token: @token) %>)
+[Click here to confirm your email address.](<%= editorial_url_for(confirmation_path(@resource, confirmation_token: @token)) %>)
 
 Thank you
 

--- a/app/views/devise/mailer/reset_password_instructions.markerb
+++ b/app/views/devise/mailer/reset_password_instructions.markerb
@@ -2,7 +2,7 @@ Hello <%= @resource.email %>!
 
 Someone has requested a link to change your password, and you can do this through the link below.
 
-[Change my password](<%= edit_password_url(@resource, reset_password_token: @token) %>)
+[Change my password](<%= editorial_url_for(edit_password_path(@resource, reset_password_token: @token)) %>)
 
 If you didn't request this, please ignore this email.
 Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/mailer/unlock_instructions.markerb
+++ b/app/views/devise/mailer/unlock_instructions.markerb
@@ -4,4 +4,4 @@ Your account has been locked due to an excessive number of unsuccessful sign in 
 
 Click the link below to unlock your account:
 
-[Unlock my account](<%= unlock_url(@resource, unlock_token: @token) %>)
+[Unlock my account](<%= editorial_url_for(unlock_path(@resource, unlock_token: @token)) %>)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,4 +72,6 @@ Rails.application.configure do
 
   #Set use of two-factor auth
   config.use_2fa = ENV['FORCE_2FA'].present?
+
+  config.editorial_base_url = "http://localhost:#{port}"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -144,4 +144,6 @@ Rails.application.configure do
                                 # The fully-qualified domain name (FQDN) that is the alias to the S3 domain of your bucket.
                                 url: ":s3_alias_url"
                             }
+
+  config.editorial_base_url = "https://#{ENV['EDITORIAL_BASE_URL']}" || "https://#{ENV['APP_DOMAIN']}"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,5 +61,5 @@ Rails.application.configure do
   config.use_2fa = true
 
   config.require_invite = false
-
+  config.editorial_base_url = 'http://localhost:3000'
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -17,6 +17,7 @@ Devise.setup do |config|
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
+  config.mailer = 'GovauMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  context 'with a separate editorial url' do
+    it 'provides the correct editorial url for' do
+      expect(editorial_url_for('/bar')).to eq("#{Rails.configuration.editorial_base_url}/bar")
+    end
+  end
+end


### PR DESCRIPTION
Replace absolute URLs with URLs pointing to editorial domain for devise mailer views.
